### PR TITLE
Remove leftover schema comments

### DIFF
--- a/backend/app/schemas/call_security_question.py
+++ b/backend/app/schemas/call_security_question.py
@@ -15,6 +15,3 @@ class CallSecurityQuestionRead(CallSecurityQuestionBase):
 
     class Config:
         orm_mode = True
-
-
-# Application schemas

--- a/backend/app/schemas/institution.py
+++ b/backend/app/schemas/institution.py
@@ -15,6 +15,3 @@ class InstitutionRead(InstitutionBase):
 
     class Config:
         orm_mode = True
-
-
-# Supervisor schemas

--- a/backend/app/schemas/supervisor.py
+++ b/backend/app/schemas/supervisor.py
@@ -17,6 +17,3 @@ class SupervisorRead(SupervisorBase):
 
     class Config:
         orm_mode = True
-
-
-# Call schemas

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -18,6 +18,3 @@ class UserRead(UserBase):
 
     class Config:
         orm_mode = True
-
-
-# Institution schemas


### PR DESCRIPTION
## Summary
- clean up stray comments in schema modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685073803e0c832cb1a2f86511797adf