### PR TITLE
Fix typo in security EUCI schema name

### DIFF
--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -19,7 +19,7 @@ from .institution import InstitutionBase, InstitutionCreate, InstitutionRead
 from .mobility_entry import MobilityEntryBase, MobilityEntryCreate, MobilityEntryRead
 from .review_report import ReviewReportBase, ReviewReportCreate, ReviewReportRead
 from .security_answer import SecurityAnswerBase, SecurityAnswerCreate, SecurityAnswerRead
-from .security_euci import SecurityEUCIBase, SecurityEUCCreate, SecurityEUCRead
+from .security_euci import SecurityEUCIBase, SecurityEUCCreate, SecurityEUCIRead
 from .security_meta import SecurityMetaBase, SecurityMetaCreate, SecurityMetaRead
 from .security_misuse import SecurityMisuseBase, SecurityMisuseCreate, SecurityMisuseRead
 from .security_other import SecurityOtherBase, SecurityOtherCreate, SecurityOtherRead
@@ -93,7 +93,7 @@ __all__ = [
     "SecurityAnswerRead",
     "SecurityEUCIBase",
     "SecurityEUCCreate",
-    "SecurityEUCRead",
+    "SecurityEUCIRead",
     "SecurityMetaBase",
     "SecurityMetaCreate",
     "SecurityMetaRead",

--- a/backend/app/schemas/security_euci.py
+++ b/backend/app/schemas/security_euci.py
@@ -11,7 +11,7 @@ class SecurityEUCCreate(SecurityEUCIBase):
     pass
 
 
-class SecurityEUCRead(SecurityEUCIBase):
+class SecurityEUCIRead(SecurityEUCIBase):
     id: uuid.UUID
 
     class Config:


### PR DESCRIPTION
## Summary
- rename `SecurityEUCRead` to `SecurityEUCIRead`
- update imports and `__all__` references

## Testing
- `python -m py_compile backend/app/schemas/security_euci.py backend/app/schemas/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_685073824f44832c95584679063974b6