### PR TITLE
Add init_db helper for schema creation

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,3 +1,13 @@
 # Project Call Platform
 
-Bu proje, FastAPI, SQLAlchemy ve Pydantic kullanarak akademik projelerin başvuru süreçlerini yönetmek için başlangıç bir iskelet sunar.
+Bu proje, FastAPI, SQLAlchemy ve Pydantic kullanarak akademik projelerin başvuru
+süreçlerini yönetmek için başlangıç bir iskelet sunar.
+
+## Database Initialization
+
+İlk kez çalıştırmadan önce veritabanı tablolarını oluşturmanız gerekir.
+
+```bash
+python -c "from app.database import init_db; init_db()"
+```
+

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,11 @@
+"""Application package initialization."""
+
+from .database import Base, SessionLocal, engine, get_db, init_db
+
+__all__ = [
+    "Base",
+    "SessionLocal",
+    "engine",
+    "get_db",
+    "init_db",
+]

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -14,3 +14,17 @@ def get_db():
         yield db
     finally:
         db.close()
+
+
+def init_db() -> None:
+    """Create all tables in the database."""
+    Base.metadata.create_all(bind=engine)
+
+
+__all__ = [
+    "engine",
+    "SessionLocal",
+    "Base",
+    "get_db",
+    "init_db",
+]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,12 @@
 from fastapi import FastAPI
+from .database import init_db
 
 app = FastAPI(title="Project Call Platform")
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    init_db()
 
 @app.get("/")
 def read_root():


### PR DESCRIPTION
## Summary
- add `init_db` in `database.py` to create tables
- expose database utilities via package `__init__`
- create startup hook in `main.py` to run `init_db`
- document database initialization in `backend/README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507386bd9c832c8b36b158e58375a9