### PR TITLE
Add CRUD layer for all models

### DIFF
--- a/backend/app/crud/__init__.py
+++ b/backend/app/crud/__init__.py
@@ -1,0 +1,59 @@
+from . import call_template
+from . import security_euci
+from . import ethics_issue
+from . import suggested_reference
+from . import application_info
+from . import call
+from . import security_other
+from . import call_ethics_question
+from . import ethical_optional_table
+from . import academic_portfolio
+from . import security_misuse
+from . import application
+from . import review_report
+from . import ethics_meta
+from . import institution
+from . import call_institution
+from . import mobility_entry
+from . import call_required_document
+from . import academic_reference
+from . import application_form
+from . import ethics_answer
+from . import call_supervisor
+from . import attachment
+from . import supervisor
+from . import call_security_question
+from . import security_meta
+from . import user
+from . import security_answer
+
+__all__ = [
+    "call_template",
+    "security_euci",
+    "ethics_issue",
+    "suggested_reference",
+    "application_info",
+    "call",
+    "security_other",
+    "call_ethics_question",
+    "ethical_optional_table",
+    "academic_portfolio",
+    "security_misuse",
+    "application",
+    "review_report",
+    "ethics_meta",
+    "institution",
+    "call_institution",
+    "mobility_entry",
+    "call_required_document",
+    "academic_reference",
+    "application_form",
+    "ethics_answer",
+    "call_supervisor",
+    "attachment",
+    "supervisor",
+    "call_security_question",
+    "security_meta",
+    "user",
+    "security_answer"
+]

--- a/backend/app/crud/academic_portfolio.py
+++ b/backend/app/crud/academic_portfolio.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import Session
+
+from ..models import AcademicPortfolio
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> AcademicPortfolio:
+    return _create(db, AcademicPortfolio, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, AcademicPortfolio, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, AcademicPortfolio)
+
+
+def update(db: Session, obj: AcademicPortfolio, data: dict) -> AcademicPortfolio:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: AcademicPortfolio) -> None:
+    _delete(db, obj)
+
+
+def get_academic_portfolios_by_application_form_id(db: Session, application_form_id: str):
+    return get_all_by_field(db, AcademicPortfolio, 'application_form_id', application_form_id)

--- a/backend/app/crud/academic_reference.py
+++ b/backend/app/crud/academic_reference.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import Session
+
+from ..models import AcademicReference
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> AcademicReference:
+    return _create(db, AcademicReference, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, AcademicReference, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, AcademicReference)
+
+
+def update(db: Session, obj: AcademicReference, data: dict) -> AcademicReference:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: AcademicReference) -> None:
+    _delete(db, obj)
+
+
+def get_academic_references_by_application_form_id(db: Session, application_form_id: str):
+    return get_all_by_field(db, AcademicReference, 'application_form_id', application_form_id)

--- a/backend/app/crud/application.py
+++ b/backend/app/crud/application.py
@@ -1,0 +1,32 @@
+from sqlalchemy.orm import Session
+
+from ..models import Application
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> Application:
+    return _create(db, Application, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, Application, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, Application)
+
+
+def update(db: Session, obj: Application, data: dict) -> Application:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: Application) -> None:
+    _delete(db, obj)
+
+
+def get_applications_by_call_id(db: Session, call_id: str):
+    return get_all_by_field(db, Application, 'call_id', call_id)
+
+
+def get_applications_by_user_id(db: Session, user_id: str):
+    return get_all_by_field(db, Application, 'user_id', user_id)

--- a/backend/app/crud/application_form.py
+++ b/backend/app/crud/application_form.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import Session
+
+from ..models import ApplicationForm
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> ApplicationForm:
+    return _create(db, ApplicationForm, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, ApplicationForm, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, ApplicationForm)
+
+
+def update(db: Session, obj: ApplicationForm, data: dict) -> ApplicationForm:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: ApplicationForm) -> None:
+    _delete(db, obj)
+
+
+def get_application_forms_by_application_id(db: Session, application_id: str):
+    return get_all_by_field(db, ApplicationForm, 'application_id', application_id)

--- a/backend/app/crud/application_info.py
+++ b/backend/app/crud/application_info.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import Session
+
+from ..models import ApplicationInfo
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> ApplicationInfo:
+    return _create(db, ApplicationInfo, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, ApplicationInfo, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, ApplicationInfo)
+
+
+def update(db: Session, obj: ApplicationInfo, data: dict) -> ApplicationInfo:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: ApplicationInfo) -> None:
+    _delete(db, obj)
+
+
+def get_application_infos_by_application_id(db: Session, application_id: str):
+    return get_all_by_field(db, ApplicationInfo, 'application_id', application_id)

--- a/backend/app/crud/attachment.py
+++ b/backend/app/crud/attachment.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import Session
+
+from ..models import Attachment
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> Attachment:
+    return _create(db, Attachment, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, Attachment, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, Attachment)
+
+
+def update(db: Session, obj: Attachment, data: dict) -> Attachment:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: Attachment) -> None:
+    _delete(db, obj)
+
+
+def get_attachments_by_application_id(db: Session, application_id: str):
+    return get_all_by_field(db, Attachment, 'application_id', application_id)

--- a/backend/app/crud/base.py
+++ b/backend/app/crud/base.py
@@ -1,0 +1,41 @@
+from typing import Type, TypeVar, Iterable, Any
+
+from sqlalchemy.orm import Session
+
+ModelType = TypeVar("ModelType")
+
+
+def create(db: Session, model: Type[ModelType], data: dict) -> ModelType:
+    # Ignore binary fields; store file paths instead
+    data = {k: v for k, v in data.items() if not k.endswith('_blob')}
+    obj = model(**data)
+    db.add(obj)
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+
+def get_by_id(db: Session, model: Type[ModelType], obj_id: Any) -> ModelType | None:
+    return db.query(model).filter(model.id == obj_id).first()
+
+
+def get_all(db: Session, model: Type[ModelType]) -> Iterable[ModelType]:
+    return db.query(model).all()
+
+
+def update(db: Session, obj: ModelType, data: dict) -> ModelType:
+    data = {k: v for k, v in data.items() if not k.endswith('_blob')}
+    for field, value in data.items():
+        setattr(obj, field, value)
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+
+def delete(db: Session, obj: ModelType) -> None:
+    db.delete(obj)
+    db.commit()
+
+
+def get_all_by_field(db: Session, model: Type[ModelType], field: str, value: Any) -> Iterable[ModelType]:
+    return db.query(model).filter(getattr(model, field) == value).all()

--- a/backend/app/crud/call.py
+++ b/backend/app/crud/call.py
@@ -1,0 +1,24 @@
+from sqlalchemy.orm import Session
+
+from ..models import Call
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> Call:
+    return _create(db, Call, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, Call, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, Call)
+
+
+def update(db: Session, obj: Call, data: dict) -> Call:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: Call) -> None:
+    _delete(db, obj)

--- a/backend/app/crud/call_ethics_question.py
+++ b/backend/app/crud/call_ethics_question.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import Session
+
+from ..models import CallEthicsQuestion
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> CallEthicsQuestion:
+    return _create(db, CallEthicsQuestion, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, CallEthicsQuestion, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, CallEthicsQuestion)
+
+
+def update(db: Session, obj: CallEthicsQuestion, data: dict) -> CallEthicsQuestion:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: CallEthicsQuestion) -> None:
+    _delete(db, obj)
+
+
+def get_call_ethics_questions_by_call_id(db: Session, call_id: str):
+    return get_all_by_field(db, CallEthicsQuestion, 'call_id', call_id)

--- a/backend/app/crud/call_institution.py
+++ b/backend/app/crud/call_institution.py
@@ -1,0 +1,32 @@
+from sqlalchemy.orm import Session
+
+from ..models import CallInstitution
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> CallInstitution:
+    return _create(db, CallInstitution, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, CallInstitution, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, CallInstitution)
+
+
+def update(db: Session, obj: CallInstitution, data: dict) -> CallInstitution:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: CallInstitution) -> None:
+    _delete(db, obj)
+
+
+def get_call_institutions_by_call_id(db: Session, call_id: str):
+    return get_all_by_field(db, CallInstitution, 'call_id', call_id)
+
+
+def get_call_institutions_by_institution_id(db: Session, institution_id: str):
+    return get_all_by_field(db, CallInstitution, 'institution_id', institution_id)

--- a/backend/app/crud/call_required_document.py
+++ b/backend/app/crud/call_required_document.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import Session
+
+from ..models import CallRequiredDocument
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> CallRequiredDocument:
+    return _create(db, CallRequiredDocument, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, CallRequiredDocument, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, CallRequiredDocument)
+
+
+def update(db: Session, obj: CallRequiredDocument, data: dict) -> CallRequiredDocument:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: CallRequiredDocument) -> None:
+    _delete(db, obj)
+
+
+def get_call_required_documents_by_call_id(db: Session, call_id: str):
+    return get_all_by_field(db, CallRequiredDocument, 'call_id', call_id)

--- a/backend/app/crud/call_security_question.py
+++ b/backend/app/crud/call_security_question.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import Session
+
+from ..models import CallSecurityQuestion
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> CallSecurityQuestion:
+    return _create(db, CallSecurityQuestion, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, CallSecurityQuestion, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, CallSecurityQuestion)
+
+
+def update(db: Session, obj: CallSecurityQuestion, data: dict) -> CallSecurityQuestion:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: CallSecurityQuestion) -> None:
+    _delete(db, obj)
+
+
+def get_call_security_questions_by_call_id(db: Session, call_id: str):
+    return get_all_by_field(db, CallSecurityQuestion, 'call_id', call_id)

--- a/backend/app/crud/call_supervisor.py
+++ b/backend/app/crud/call_supervisor.py
@@ -1,0 +1,32 @@
+from sqlalchemy.orm import Session
+
+from ..models import CallSupervisor
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> CallSupervisor:
+    return _create(db, CallSupervisor, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, CallSupervisor, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, CallSupervisor)
+
+
+def update(db: Session, obj: CallSupervisor, data: dict) -> CallSupervisor:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: CallSupervisor) -> None:
+    _delete(db, obj)
+
+
+def get_call_supervisors_by_call_id(db: Session, call_id: str):
+    return get_all_by_field(db, CallSupervisor, 'call_id', call_id)
+
+
+def get_call_supervisors_by_supervisor_id(db: Session, supervisor_id: str):
+    return get_all_by_field(db, CallSupervisor, 'supervisor_id', supervisor_id)

--- a/backend/app/crud/call_template.py
+++ b/backend/app/crud/call_template.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import Session
+
+from ..models import CallTemplate
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> CallTemplate:
+    return _create(db, CallTemplate, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, CallTemplate, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, CallTemplate)
+
+
+def update(db: Session, obj: CallTemplate, data: dict) -> CallTemplate:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: CallTemplate) -> None:
+    _delete(db, obj)
+
+
+def get_call_templates_by_call_id(db: Session, call_id: str):
+    return get_all_by_field(db, CallTemplate, 'call_id', call_id)

--- a/backend/app/crud/ethical_optional_table.py
+++ b/backend/app/crud/ethical_optional_table.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import Session
+
+from ..models import EthicalOptionalTable
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> EthicalOptionalTable:
+    return _create(db, EthicalOptionalTable, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, EthicalOptionalTable, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, EthicalOptionalTable)
+
+
+def update(db: Session, obj: EthicalOptionalTable, data: dict) -> EthicalOptionalTable:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: EthicalOptionalTable) -> None:
+    _delete(db, obj)
+
+
+def get_ethical_optional_tables_by_application_form_id(db: Session, application_form_id: str):
+    return get_all_by_field(db, EthicalOptionalTable, 'application_form_id', application_form_id)

--- a/backend/app/crud/ethics_answer.py
+++ b/backend/app/crud/ethics_answer.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import Session
+
+from ..models import EthicsAnswer
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> EthicsAnswer:
+    return _create(db, EthicsAnswer, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, EthicsAnswer, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, EthicsAnswer)
+
+
+def update(db: Session, obj: EthicsAnswer, data: dict) -> EthicsAnswer:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: EthicsAnswer) -> None:
+    _delete(db, obj)
+
+
+def get_ethics_answers_by_application_form_id(db: Session, application_form_id: str):
+    return get_all_by_field(db, EthicsAnswer, 'application_form_id', application_form_id)

--- a/backend/app/crud/ethics_issue.py
+++ b/backend/app/crud/ethics_issue.py
@@ -1,0 +1,32 @@
+from sqlalchemy.orm import Session
+
+from ..models import EthicsIssue
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> EthicsIssue:
+    return _create(db, EthicsIssue, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, EthicsIssue, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, EthicsIssue)
+
+
+def update(db: Session, obj: EthicsIssue, data: dict) -> EthicsIssue:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: EthicsIssue) -> None:
+    _delete(db, obj)
+
+
+def get_ethics_issues_by_application_form_id(db: Session, application_form_id: str):
+    return get_all_by_field(db, EthicsIssue, 'application_form_id', application_form_id)
+
+
+def get_ethics_issues_by_meta_id(db: Session, meta_id: str):
+    return get_all_by_field(db, EthicsIssue, 'meta_id', meta_id)

--- a/backend/app/crud/ethics_meta.py
+++ b/backend/app/crud/ethics_meta.py
@@ -1,0 +1,24 @@
+from sqlalchemy.orm import Session
+
+from ..models import EthicsMeta
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> EthicsMeta:
+    return _create(db, EthicsMeta, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, EthicsMeta, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, EthicsMeta)
+
+
+def update(db: Session, obj: EthicsMeta, data: dict) -> EthicsMeta:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: EthicsMeta) -> None:
+    _delete(db, obj)

--- a/backend/app/crud/institution.py
+++ b/backend/app/crud/institution.py
@@ -1,0 +1,24 @@
+from sqlalchemy.orm import Session
+
+from ..models import Institution
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> Institution:
+    return _create(db, Institution, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, Institution, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, Institution)
+
+
+def update(db: Session, obj: Institution, data: dict) -> Institution:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: Institution) -> None:
+    _delete(db, obj)

--- a/backend/app/crud/mobility_entry.py
+++ b/backend/app/crud/mobility_entry.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import Session
+
+from ..models import MobilityEntry
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> MobilityEntry:
+    return _create(db, MobilityEntry, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, MobilityEntry, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, MobilityEntry)
+
+
+def update(db: Session, obj: MobilityEntry, data: dict) -> MobilityEntry:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: MobilityEntry) -> None:
+    _delete(db, obj)
+
+
+def get_mobility_entrys_by_application_form_id(db: Session, application_form_id: str):
+    return get_all_by_field(db, MobilityEntry, 'application_form_id', application_form_id)

--- a/backend/app/crud/review_report.py
+++ b/backend/app/crud/review_report.py
@@ -1,0 +1,36 @@
+from sqlalchemy.orm import Session
+
+from ..models import ReviewReport
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> ReviewReport:
+    return _create(db, ReviewReport, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, ReviewReport, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, ReviewReport)
+
+
+def update(db: Session, obj: ReviewReport, data: dict) -> ReviewReport:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: ReviewReport) -> None:
+    _delete(db, obj)
+
+
+def get_review_reports_by_call_id(db: Session, call_id: str):
+    return get_all_by_field(db, ReviewReport, 'call_id', call_id)
+
+
+def get_review_reports_by_application_id(db: Session, application_id: str):
+    return get_all_by_field(db, ReviewReport, 'application_id', application_id)
+
+
+def get_review_reports_by_reviewer_id(db: Session, reviewer_id: str):
+    return get_all_by_field(db, ReviewReport, 'reviewer_id', reviewer_id)

--- a/backend/app/crud/security_answer.py
+++ b/backend/app/crud/security_answer.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import Session
+
+from ..models import SecurityAnswer
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> SecurityAnswer:
+    return _create(db, SecurityAnswer, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, SecurityAnswer, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, SecurityAnswer)
+
+
+def update(db: Session, obj: SecurityAnswer, data: dict) -> SecurityAnswer:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: SecurityAnswer) -> None:
+    _delete(db, obj)
+
+
+def get_security_answers_by_application_form_id(db: Session, application_form_id: str):
+    return get_all_by_field(db, SecurityAnswer, 'application_form_id', application_form_id)

--- a/backend/app/crud/security_euci.py
+++ b/backend/app/crud/security_euci.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import Session
+
+from ..models import SecurityEuci
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> SecurityEuci:
+    return _create(db, SecurityEuci, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, SecurityEuci, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, SecurityEuci)
+
+
+def update(db: Session, obj: SecurityEuci, data: dict) -> SecurityEuci:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: SecurityEuci) -> None:
+    _delete(db, obj)
+
+
+def get_security_eucis_by_application_form_id(db: Session, application_form_id: str):
+    return get_all_by_field(db, SecurityEuci, 'application_form_id', application_form_id)

--- a/backend/app/crud/security_meta.py
+++ b/backend/app/crud/security_meta.py
@@ -1,0 +1,24 @@
+from sqlalchemy.orm import Session
+
+from ..models import SecurityMeta
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> SecurityMeta:
+    return _create(db, SecurityMeta, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, SecurityMeta, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, SecurityMeta)
+
+
+def update(db: Session, obj: SecurityMeta, data: dict) -> SecurityMeta:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: SecurityMeta) -> None:
+    _delete(db, obj)

--- a/backend/app/crud/security_misuse.py
+++ b/backend/app/crud/security_misuse.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import Session
+
+from ..models import SecurityMisuse
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> SecurityMisuse:
+    return _create(db, SecurityMisuse, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, SecurityMisuse, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, SecurityMisuse)
+
+
+def update(db: Session, obj: SecurityMisuse, data: dict) -> SecurityMisuse:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: SecurityMisuse) -> None:
+    _delete(db, obj)
+
+
+def get_security_misuses_by_application_form_id(db: Session, application_form_id: str):
+    return get_all_by_field(db, SecurityMisuse, 'application_form_id', application_form_id)

--- a/backend/app/crud/security_other.py
+++ b/backend/app/crud/security_other.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import Session
+
+from ..models import SecurityOther
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> SecurityOther:
+    return _create(db, SecurityOther, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, SecurityOther, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, SecurityOther)
+
+
+def update(db: Session, obj: SecurityOther, data: dict) -> SecurityOther:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: SecurityOther) -> None:
+    _delete(db, obj)
+
+
+def get_security_others_by_application_form_id(db: Session, application_form_id: str):
+    return get_all_by_field(db, SecurityOther, 'application_form_id', application_form_id)

--- a/backend/app/crud/suggested_reference.py
+++ b/backend/app/crud/suggested_reference.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import Session
+
+from ..models import SuggestedReference
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> SuggestedReference:
+    return _create(db, SuggestedReference, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, SuggestedReference, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, SuggestedReference)
+
+
+def update(db: Session, obj: SuggestedReference, data: dict) -> SuggestedReference:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: SuggestedReference) -> None:
+    _delete(db, obj)
+
+
+def get_suggested_references_by_application_form_id(db: Session, application_form_id: str):
+    return get_all_by_field(db, SuggestedReference, 'application_form_id', application_form_id)

--- a/backend/app/crud/supervisor.py
+++ b/backend/app/crud/supervisor.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import Session
+
+from ..models import Supervisor
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> Supervisor:
+    return _create(db, Supervisor, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, Supervisor, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, Supervisor)
+
+
+def update(db: Session, obj: Supervisor, data: dict) -> Supervisor:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: Supervisor) -> None:
+    _delete(db, obj)
+
+
+def get_supervisors_by_institution_id(db: Session, institution_id: str):
+    return get_all_by_field(db, Supervisor, 'institution_id', institution_id)

--- a/backend/app/crud/user.py
+++ b/backend/app/crud/user.py
@@ -1,0 +1,24 @@
+from sqlalchemy.orm import Session
+
+from ..models import User
+from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+
+
+def create(db: Session, data: dict) -> User:
+    return _create(db, User, data)
+
+
+def get_by_id(db: Session, obj_id):
+    return _get_by_id(db, User, obj_id)
+
+
+def get_all(db: Session):
+    return _get_all(db, User)
+
+
+def update(db: Session, obj: User, data: dict) -> User:
+    return _update(db, obj, data)
+
+
+def delete(db: Session, obj: User) -> None:
+    _delete(db, obj)


### PR DESCRIPTION
## Summary
- implement CRUD helpers for every SQLAlchemy model
- centralize generic helpers in `crud/base.py`
- export CRUD modules via `crud/__init__.py`

## Testing
- `python3 -m compileall backend/app/crud`

------
https://chatgpt.com/codex/tasks/task_e_6850762fe258832c93d0cd937de4a9c6