### PR TITLE
Add initial CRUD API routes

### DIFF
--- a/backend/app/crud/__init__.py
+++ b/backend/app/crud/__init__.py
@@ -1,0 +1,27 @@
+from .user import (
+    create_user,
+    delete_user,
+    get_user,
+    get_users,
+    update_user,
+)
+from .call import (
+    create_call,
+    delete_call,
+    get_call,
+    get_calls,
+    update_call,
+)
+
+__all__ = [
+    "create_user",
+    "delete_user",
+    "get_user",
+    "get_users",
+    "update_user",
+    "create_call",
+    "delete_call",
+    "get_call",
+    "get_calls",
+    "update_call",
+]

--- a/backend/app/crud/call.py
+++ b/backend/app/crud/call.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import uuid
+from typing import List, Optional
+
+from sqlalchemy.orm import Session
+
+from ..models.call import Call
+from ..schemas.call import CallCreate
+
+
+def get_calls(db: Session) -> List[Call]:
+    return db.query(Call).all()
+
+
+def get_call(db: Session, call_id: uuid.UUID) -> Optional[Call]:
+    return db.query(Call).filter(Call.id == call_id).first()
+
+
+def create_call(db: Session, call_in: CallCreate) -> Call:
+    db_call = Call(
+        title=call_in.title,
+        description=call_in.description,
+        status=call_in.status,
+        start_date=call_in.start_date,
+        end_date=call_in.end_date,
+    )
+    db.add(db_call)
+    db.commit()
+    db.refresh(db_call)
+    return db_call
+
+
+def update_call(db: Session, db_call: Call, call_in: CallCreate) -> Call:
+    db_call.title = call_in.title
+    db_call.description = call_in.description
+    db_call.status = call_in.status
+    db_call.start_date = call_in.start_date
+    db_call.end_date = call_in.end_date
+    db.commit()
+    db.refresh(db_call)
+    return db_call
+
+
+def delete_call(db: Session, db_call: Call) -> None:
+    db.delete(db_call)
+    db.commit()

--- a/backend/app/crud/user.py
+++ b/backend/app/crud/user.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import uuid
+from typing import List, Optional
+
+from sqlalchemy.orm import Session
+
+from ..models.user import User
+from ..schemas.user import UserCreate
+
+
+def get_users(db: Session) -> List[User]:
+    return db.query(User).all()
+
+
+def get_user(db: Session, user_id: uuid.UUID) -> Optional[User]:
+    return db.query(User).filter(User.id == user_id).first()
+
+
+def create_user(db: Session, user_in: UserCreate) -> User:
+    db_user = User(
+        email=user_in.email,
+        first_name=user_in.first_name,
+        last_name=user_in.last_name,
+        role=user_in.role,
+        password_hash=user_in.password,
+    )
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+def update_user(db: Session, db_user: User, user_in: UserCreate) -> User:
+    db_user.email = user_in.email
+    db_user.first_name = user_in.first_name
+    db_user.last_name = user_in.last_name
+    db_user.role = user_in.role
+    db_user.password_hash = user_in.password
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+def delete_user(db: Session, db_user: User) -> None:
+    db.delete(db_user)
+    db.commit()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,7 @@
 from fastapi import FastAPI
+
 from .database import init_db
+from .routes import api_router
 
 app = FastAPI(title="Project Call Platform")
 
@@ -11,3 +13,5 @@ def on_startup() -> None:
 @app.get("/")
 def read_root():
     return {"message": "Welcome to Project Call Platform"}
+
+app.include_router(api_router)

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+
+from .user import router as user_router
+from .call import router as call_router
+
+api_router = APIRouter()
+api_router.include_router(user_router)
+api_router.include_router(call_router)
+
+__all__ = ["api_router"]

--- a/backend/app/routes/call.py
+++ b/backend/app/routes/call.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import uuid
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from ..schemas import CallCreate, CallRead
+from ..crud import call as crud_call
+
+router = APIRouter(prefix="/calls", tags=["calls"])
+
+
+@router.post("/", response_model=CallRead, status_code=status.HTTP_201_CREATED)
+def create_call(call_in: CallCreate, db: Session = Depends(get_db)) -> CallRead:
+    return crud_call.create_call(db, call_in)
+
+
+@router.get("/", response_model=List[CallRead])
+def list_calls(db: Session = Depends(get_db)) -> List[CallRead]:
+    return crud_call.get_calls(db)
+
+
+@router.get("/{call_id}", response_model=CallRead)
+def read_call(call_id: uuid.UUID, db: Session = Depends(get_db)) -> CallRead:
+    db_call = crud_call.get_call(db, call_id)
+    if not db_call:
+        raise HTTPException(status_code=404, detail="Call not found")
+    return db_call
+
+
+@router.put("/{call_id}", response_model=CallRead)
+def update_call(call_id: uuid.UUID, call_in: CallCreate, db: Session = Depends(get_db)) -> CallRead:
+    db_call = crud_call.get_call(db, call_id)
+    if not db_call:
+        raise HTTPException(status_code=404, detail="Call not found")
+    return crud_call.update_call(db, db_call, call_in)
+
+
+@router.delete("/{call_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_call(call_id: uuid.UUID, db: Session = Depends(get_db)) -> None:
+    db_call = crud_call.get_call(db, call_id)
+    if not db_call:
+        raise HTTPException(status_code=404, detail="Call not found")
+    crud_call.delete_call(db, db_call)
+    return None

--- a/backend/app/routes/user.py
+++ b/backend/app/routes/user.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import uuid
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from ..schemas import UserCreate, UserRead
+from ..crud import user as crud_user
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+@router.post("/", response_model=UserRead, status_code=status.HTTP_201_CREATED)
+def create_user(user_in: UserCreate, db: Session = Depends(get_db)) -> UserRead:
+    return crud_user.create_user(db, user_in)
+
+
+@router.get("/", response_model=List[UserRead])
+def list_users(db: Session = Depends(get_db)) -> List[UserRead]:
+    return crud_user.get_users(db)
+
+
+@router.get("/{user_id}", response_model=UserRead)
+def read_user(user_id: uuid.UUID, db: Session = Depends(get_db)) -> UserRead:
+    db_user = crud_user.get_user(db, user_id)
+    if not db_user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return db_user
+
+
+@router.put("/{user_id}", response_model=UserRead)
+def update_user(user_id: uuid.UUID, user_in: UserCreate, db: Session = Depends(get_db)) -> UserRead:
+    db_user = crud_user.get_user(db, user_id)
+    if not db_user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return crud_user.update_user(db, db_user, user_in)
+
+
+@router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_user(user_id: uuid.UUID, db: Session = Depends(get_db)) -> None:
+    db_user = crud_user.get_user(db, user_id)
+    if not db_user:
+        raise HTTPException(status_code=404, detail="User not found")
+    crud_user.delete_user(db, db_user)
+    return None


### PR DESCRIPTION
## Summary
- implement CRUD helper functions for `User` and `Call` models
- create RESTful routers for users and calls
- expose routers via `routes.__init__` and include in `main`
- refine route responses to use explicit HTTP status codes

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68507630aef8832c9f40679947cc42d3