### PR TITLE
Add APIRouters for all models

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,10 @@
 from fastapi import FastAPI
 from .database import init_db
+from .routes import api_router
 
 app = FastAPI(title="Project Call Platform")
+
+app.include_router(api_router)
 
 
 @app.on_event("startup")

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,0 +1,65 @@
+from . import (
+    academic_portfolio,
+    academic_reference,
+    application,
+    application_form,
+    application_info,
+    attachment,
+    call,
+    call_ethics_question,
+    call_institution,
+    call_required_document,
+    call_security_question,
+    call_supervisor,
+    call_template,
+    ethical_optional_table,
+    ethics_answer,
+    ethics_issue,
+    ethics_meta,
+    institution,
+    mobility_entry,
+    review_report,
+    security_answer,
+    security_euci,
+    security_meta,
+    security_misuse,
+    security_other,
+    suggested_reference,
+    supervisor,
+    user,
+)
+
+from fastapi import APIRouter
+
+api_router = APIRouter()
+
+api_router.include_router(academic_portfolio.router)
+api_router.include_router(academic_reference.router)
+api_router.include_router(application.router)
+api_router.include_router(application_form.router)
+api_router.include_router(application_info.router)
+api_router.include_router(attachment.router)
+api_router.include_router(call.router)
+api_router.include_router(call_ethics_question.router)
+api_router.include_router(call_institution.router)
+api_router.include_router(call_required_document.router)
+api_router.include_router(call_security_question.router)
+api_router.include_router(call_supervisor.router)
+api_router.include_router(call_template.router)
+api_router.include_router(ethical_optional_table.router)
+api_router.include_router(ethics_answer.router)
+api_router.include_router(ethics_issue.router)
+api_router.include_router(ethics_meta.router)
+api_router.include_router(institution.router)
+api_router.include_router(mobility_entry.router)
+api_router.include_router(review_report.router)
+api_router.include_router(security_answer.router)
+api_router.include_router(security_euci.router)
+api_router.include_router(security_meta.router)
+api_router.include_router(security_misuse.router)
+api_router.include_router(security_other.router)
+api_router.include_router(suggested_reference.router)
+api_router.include_router(supervisor.router)
+api_router.include_router(user.router)
+
+__all__ = ["api_router"]

--- a/backend/app/routes/academic_portfolio.py
+++ b/backend/app/routes/academic_portfolio.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import academic_portfolio as crud
+from ..schemas import AcademicPortfolioCreate, AcademicPortfolioRead
+
+router = APIRouter(prefix="/academic_portfolios", tags=["AcademicPortfolio"])
+
+@router.post('/', response_model=AcademicPortfolioRead)
+def create_academic_portfolio(data: AcademicPortfolioCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=AcademicPortfolioRead)
+def read_academic_portfolio(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="AcademicPortfolio not found")
+    return obj
+
+@router.get('/', response_model=list[AcademicPortfolioRead])
+def read_academic_portfolios(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=AcademicPortfolioRead)
+def update_academic_portfolio(obj_id: uuid.UUID, data: AcademicPortfolioCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="AcademicPortfolio not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_academic_portfolio(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="AcademicPortfolio not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/academic_reference.py
+++ b/backend/app/routes/academic_reference.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import academic_reference as crud
+from ..schemas import AcademicReferenceCreate, AcademicReferenceRead
+
+router = APIRouter(prefix="/academic_references", tags=["AcademicReference"])
+
+@router.post('/', response_model=AcademicReferenceRead)
+def create_academic_reference(data: AcademicReferenceCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=AcademicReferenceRead)
+def read_academic_reference(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="AcademicReference not found")
+    return obj
+
+@router.get('/', response_model=list[AcademicReferenceRead])
+def read_academic_references(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=AcademicReferenceRead)
+def update_academic_reference(obj_id: uuid.UUID, data: AcademicReferenceCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="AcademicReference not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_academic_reference(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="AcademicReference not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/application.py
+++ b/backend/app/routes/application.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import application as crud
+from ..schemas import ApplicationCreate, ApplicationRead
+
+router = APIRouter(prefix="/applications", tags=["Application"])
+
+@router.post('/', response_model=ApplicationRead)
+def create_application(data: ApplicationCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=ApplicationRead)
+def read_application(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Application not found")
+    return obj
+
+@router.get('/', response_model=list[ApplicationRead])
+def read_applications(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=ApplicationRead)
+def update_application(obj_id: uuid.UUID, data: ApplicationCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Application not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_application(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Application not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/application_form.py
+++ b/backend/app/routes/application_form.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import application_form as crud
+from ..schemas import ApplicationFormCreate, ApplicationFormRead
+
+router = APIRouter(prefix="/application_forms", tags=["ApplicationForm"])
+
+@router.post('/', response_model=ApplicationFormRead)
+def create_application_form(data: ApplicationFormCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=ApplicationFormRead)
+def read_application_form(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    return obj
+
+@router.get('/', response_model=list[ApplicationFormRead])
+def read_application_forms(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=ApplicationFormRead)
+def update_application_form(obj_id: uuid.UUID, data: ApplicationFormCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_application_form(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/application_info.py
+++ b/backend/app/routes/application_info.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import application_info as crud
+from ..schemas import ApplicationInfoCreate, ApplicationInfoRead
+
+router = APIRouter(prefix="/application_infos", tags=["ApplicationInfo"])
+
+@router.post('/', response_model=ApplicationInfoRead)
+def create_application_info(data: ApplicationInfoCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=ApplicationInfoRead)
+def read_application_info(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="ApplicationInfo not found")
+    return obj
+
+@router.get('/', response_model=list[ApplicationInfoRead])
+def read_application_infos(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=ApplicationInfoRead)
+def update_application_info(obj_id: uuid.UUID, data: ApplicationInfoCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="ApplicationInfo not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_application_info(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="ApplicationInfo not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/attachment.py
+++ b/backend/app/routes/attachment.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import attachment as crud
+from ..schemas import AttachmentCreate, AttachmentRead
+
+router = APIRouter(prefix="/attachments", tags=["Attachment"])
+
+@router.post('/', response_model=AttachmentRead)
+def create_attachment(data: AttachmentCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=AttachmentRead)
+def read_attachment(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Attachment not found")
+    return obj
+
+@router.get('/', response_model=list[AttachmentRead])
+def read_attachments(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=AttachmentRead)
+def update_attachment(obj_id: uuid.UUID, data: AttachmentCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Attachment not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_attachment(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Attachment not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/call.py
+++ b/backend/app/routes/call.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import call as crud
+from ..schemas import CallCreate, CallRead
+
+router = APIRouter(prefix="/calls", tags=["Call"])
+
+@router.post('/', response_model=CallRead)
+def create_call(data: CallCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=CallRead)
+def read_call(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Call not found")
+    return obj
+
+@router.get('/', response_model=list[CallRead])
+def read_calls(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=CallRead)
+def update_call(obj_id: uuid.UUID, data: CallCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Call not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_call(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Call not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/call_ethics_question.py
+++ b/backend/app/routes/call_ethics_question.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import call_ethics_question as crud
+from ..schemas import CallEthicsQuestionCreate, CallEthicsQuestionRead
+
+router = APIRouter(prefix="/call_ethics_questions", tags=["CallEthicsQuestion"])
+
+@router.post('/', response_model=CallEthicsQuestionRead)
+def create_call_ethics_question(data: CallEthicsQuestionCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=CallEthicsQuestionRead)
+def read_call_ethics_question(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="CallEthicsQuestion not found")
+    return obj
+
+@router.get('/', response_model=list[CallEthicsQuestionRead])
+def read_call_ethics_questions(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=CallEthicsQuestionRead)
+def update_call_ethics_question(obj_id: uuid.UUID, data: CallEthicsQuestionCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="CallEthicsQuestion not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_call_ethics_question(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="CallEthicsQuestion not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/call_institution.py
+++ b/backend/app/routes/call_institution.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import call_institution as crud
+from ..schemas import CallInstitutionCreate, CallInstitutionRead
+
+router = APIRouter(prefix="/call_institutions", tags=["CallInstitution"])
+
+@router.post('/', response_model=CallInstitutionRead)
+def create_call_institution(data: CallInstitutionCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=CallInstitutionRead)
+def read_call_institution(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="CallInstitution not found")
+    return obj
+
+@router.get('/', response_model=list[CallInstitutionRead])
+def read_call_institutions(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=CallInstitutionRead)
+def update_call_institution(obj_id: uuid.UUID, data: CallInstitutionCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="CallInstitution not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_call_institution(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="CallInstitution not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/call_required_document.py
+++ b/backend/app/routes/call_required_document.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import call_required_document as crud
+from ..schemas import CallRequiredDocumentCreate, CallRequiredDocumentRead
+
+router = APIRouter(prefix="/call_required_documents", tags=["CallRequiredDocument"])
+
+@router.post('/', response_model=CallRequiredDocumentRead)
+def create_call_required_document(data: CallRequiredDocumentCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=CallRequiredDocumentRead)
+def read_call_required_document(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="CallRequiredDocument not found")
+    return obj
+
+@router.get('/', response_model=list[CallRequiredDocumentRead])
+def read_call_required_documents(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=CallRequiredDocumentRead)
+def update_call_required_document(obj_id: uuid.UUID, data: CallRequiredDocumentCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="CallRequiredDocument not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_call_required_document(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="CallRequiredDocument not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/call_security_question.py
+++ b/backend/app/routes/call_security_question.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import call_security_question as crud
+from ..schemas import CallSecurityQuestionCreate, CallSecurityQuestionRead
+
+router = APIRouter(prefix="/call_security_questions", tags=["CallSecurityQuestion"])
+
+@router.post('/', response_model=CallSecurityQuestionRead)
+def create_call_security_question(data: CallSecurityQuestionCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=CallSecurityQuestionRead)
+def read_call_security_question(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="CallSecurityQuestion not found")
+    return obj
+
+@router.get('/', response_model=list[CallSecurityQuestionRead])
+def read_call_security_questions(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=CallSecurityQuestionRead)
+def update_call_security_question(obj_id: uuid.UUID, data: CallSecurityQuestionCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="CallSecurityQuestion not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_call_security_question(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="CallSecurityQuestion not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/call_supervisor.py
+++ b/backend/app/routes/call_supervisor.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import call_supervisor as crud
+from ..schemas import CallSupervisorCreate, CallSupervisorRead
+
+router = APIRouter(prefix="/call_supervisors", tags=["CallSupervisor"])
+
+@router.post('/', response_model=CallSupervisorRead)
+def create_call_supervisor(data: CallSupervisorCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=CallSupervisorRead)
+def read_call_supervisor(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="CallSupervisor not found")
+    return obj
+
+@router.get('/', response_model=list[CallSupervisorRead])
+def read_call_supervisors(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=CallSupervisorRead)
+def update_call_supervisor(obj_id: uuid.UUID, data: CallSupervisorCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="CallSupervisor not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_call_supervisor(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="CallSupervisor not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/call_template.py
+++ b/backend/app/routes/call_template.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import call_template as crud
+from ..schemas import CallTemplateCreate, CallTemplateRead
+
+router = APIRouter(prefix="/call_templates", tags=["CallTemplate"])
+
+@router.post('/', response_model=CallTemplateRead)
+def create_call_template(data: CallTemplateCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=CallTemplateRead)
+def read_call_template(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="CallTemplate not found")
+    return obj
+
+@router.get('/', response_model=list[CallTemplateRead])
+def read_call_templates(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=CallTemplateRead)
+def update_call_template(obj_id: uuid.UUID, data: CallTemplateCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="CallTemplate not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_call_template(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="CallTemplate not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/ethical_optional_table.py
+++ b/backend/app/routes/ethical_optional_table.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import ethical_optional_table as crud
+from ..schemas import EthicalOptionalTableCreate, EthicalOptionalTableRead
+
+router = APIRouter(prefix="/ethical_optional_tables", tags=["EthicalOptionalTable"])
+
+@router.post('/', response_model=EthicalOptionalTableRead)
+def create_ethical_optional_table(data: EthicalOptionalTableCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=EthicalOptionalTableRead)
+def read_ethical_optional_table(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="EthicalOptionalTable not found")
+    return obj
+
+@router.get('/', response_model=list[EthicalOptionalTableRead])
+def read_ethical_optional_tables(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=EthicalOptionalTableRead)
+def update_ethical_optional_table(obj_id: uuid.UUID, data: EthicalOptionalTableCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="EthicalOptionalTable not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_ethical_optional_table(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="EthicalOptionalTable not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/ethics_answer.py
+++ b/backend/app/routes/ethics_answer.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import ethics_answer as crud
+from ..schemas import EthicsAnswerCreate, EthicsAnswerRead
+
+router = APIRouter(prefix="/ethics_answers", tags=["EthicsAnswer"])
+
+@router.post('/', response_model=EthicsAnswerRead)
+def create_ethics_answer(data: EthicsAnswerCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=EthicsAnswerRead)
+def read_ethics_answer(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="EthicsAnswer not found")
+    return obj
+
+@router.get('/', response_model=list[EthicsAnswerRead])
+def read_ethics_answers(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=EthicsAnswerRead)
+def update_ethics_answer(obj_id: uuid.UUID, data: EthicsAnswerCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="EthicsAnswer not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_ethics_answer(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="EthicsAnswer not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/ethics_issue.py
+++ b/backend/app/routes/ethics_issue.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import ethics_issue as crud
+from ..schemas import EthicsIssueCreate, EthicsIssueRead
+
+router = APIRouter(prefix="/ethics_issues", tags=["EthicsIssue"])
+
+@router.post('/', response_model=EthicsIssueRead)
+def create_ethics_issue(data: EthicsIssueCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=EthicsIssueRead)
+def read_ethics_issue(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="EthicsIssue not found")
+    return obj
+
+@router.get('/', response_model=list[EthicsIssueRead])
+def read_ethics_issues(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=EthicsIssueRead)
+def update_ethics_issue(obj_id: uuid.UUID, data: EthicsIssueCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="EthicsIssue not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_ethics_issue(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="EthicsIssue not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/ethics_meta.py
+++ b/backend/app/routes/ethics_meta.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import ethics_meta as crud
+from ..schemas import EthicsMetaCreate, EthicsMetaRead
+
+router = APIRouter(prefix="/ethics_metas", tags=["EthicsMeta"])
+
+@router.post('/', response_model=EthicsMetaRead)
+def create_ethics_meta(data: EthicsMetaCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=EthicsMetaRead)
+def read_ethics_meta(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="EthicsMeta not found")
+    return obj
+
+@router.get('/', response_model=list[EthicsMetaRead])
+def read_ethics_metas(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=EthicsMetaRead)
+def update_ethics_meta(obj_id: uuid.UUID, data: EthicsMetaCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="EthicsMeta not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_ethics_meta(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="EthicsMeta not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/institution.py
+++ b/backend/app/routes/institution.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import institution as crud
+from ..schemas import InstitutionCreate, InstitutionRead
+
+router = APIRouter(prefix="/institutions", tags=["Institution"])
+
+@router.post('/', response_model=InstitutionRead)
+def create_institution(data: InstitutionCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=InstitutionRead)
+def read_institution(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Institution not found")
+    return obj
+
+@router.get('/', response_model=list[InstitutionRead])
+def read_institutions(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=InstitutionRead)
+def update_institution(obj_id: uuid.UUID, data: InstitutionCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Institution not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_institution(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Institution not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/mobility_entry.py
+++ b/backend/app/routes/mobility_entry.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import mobility_entry as crud
+from ..schemas import MobilityEntryCreate, MobilityEntryRead
+
+router = APIRouter(prefix="/mobility_entrys", tags=["MobilityEntry"])
+
+@router.post('/', response_model=MobilityEntryRead)
+def create_mobility_entry(data: MobilityEntryCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=MobilityEntryRead)
+def read_mobility_entry(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="MobilityEntry not found")
+    return obj
+
+@router.get('/', response_model=list[MobilityEntryRead])
+def read_mobility_entrys(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=MobilityEntryRead)
+def update_mobility_entry(obj_id: uuid.UUID, data: MobilityEntryCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="MobilityEntry not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_mobility_entry(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="MobilityEntry not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/review_report.py
+++ b/backend/app/routes/review_report.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import review_report as crud
+from ..schemas import ReviewReportCreate, ReviewReportRead
+
+router = APIRouter(prefix="/review_reports", tags=["ReviewReport"])
+
+@router.post('/', response_model=ReviewReportRead)
+def create_review_report(data: ReviewReportCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=ReviewReportRead)
+def read_review_report(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="ReviewReport not found")
+    return obj
+
+@router.get('/', response_model=list[ReviewReportRead])
+def read_review_reports(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=ReviewReportRead)
+def update_review_report(obj_id: uuid.UUID, data: ReviewReportCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="ReviewReport not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_review_report(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="ReviewReport not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/security_answer.py
+++ b/backend/app/routes/security_answer.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import security_answer as crud
+from ..schemas import SecurityAnswerCreate, SecurityAnswerRead
+
+router = APIRouter(prefix="/security_answers", tags=["SecurityAnswer"])
+
+@router.post('/', response_model=SecurityAnswerRead)
+def create_security_answer(data: SecurityAnswerCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=SecurityAnswerRead)
+def read_security_answer(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="SecurityAnswer not found")
+    return obj
+
+@router.get('/', response_model=list[SecurityAnswerRead])
+def read_security_answers(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=SecurityAnswerRead)
+def update_security_answer(obj_id: uuid.UUID, data: SecurityAnswerCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="SecurityAnswer not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_security_answer(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="SecurityAnswer not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/security_euci.py
+++ b/backend/app/routes/security_euci.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import security_euci as crud
+from ..schemas import SecurityEuciCreate, SecurityEuciRead
+
+router = APIRouter(prefix="/security_eucis", tags=["SecurityEuci"])
+
+@router.post('/', response_model=SecurityEuciRead)
+def create_security_euci(data: SecurityEuciCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=SecurityEuciRead)
+def read_security_euci(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="SecurityEuci not found")
+    return obj
+
+@router.get('/', response_model=list[SecurityEuciRead])
+def read_security_eucis(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=SecurityEuciRead)
+def update_security_euci(obj_id: uuid.UUID, data: SecurityEuciCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="SecurityEuci not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_security_euci(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="SecurityEuci not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/security_meta.py
+++ b/backend/app/routes/security_meta.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import security_meta as crud
+from ..schemas import SecurityMetaCreate, SecurityMetaRead
+
+router = APIRouter(prefix="/security_metas", tags=["SecurityMeta"])
+
+@router.post('/', response_model=SecurityMetaRead)
+def create_security_meta(data: SecurityMetaCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=SecurityMetaRead)
+def read_security_meta(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="SecurityMeta not found")
+    return obj
+
+@router.get('/', response_model=list[SecurityMetaRead])
+def read_security_metas(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=SecurityMetaRead)
+def update_security_meta(obj_id: uuid.UUID, data: SecurityMetaCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="SecurityMeta not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_security_meta(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="SecurityMeta not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/security_misuse.py
+++ b/backend/app/routes/security_misuse.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import security_misuse as crud
+from ..schemas import SecurityMisuseCreate, SecurityMisuseRead
+
+router = APIRouter(prefix="/security_misuses", tags=["SecurityMisuse"])
+
+@router.post('/', response_model=SecurityMisuseRead)
+def create_security_misuse(data: SecurityMisuseCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=SecurityMisuseRead)
+def read_security_misuse(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="SecurityMisuse not found")
+    return obj
+
+@router.get('/', response_model=list[SecurityMisuseRead])
+def read_security_misuses(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=SecurityMisuseRead)
+def update_security_misuse(obj_id: uuid.UUID, data: SecurityMisuseCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="SecurityMisuse not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_security_misuse(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="SecurityMisuse not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/security_other.py
+++ b/backend/app/routes/security_other.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import security_other as crud
+from ..schemas import SecurityOtherCreate, SecurityOtherRead
+
+router = APIRouter(prefix="/security_others", tags=["SecurityOther"])
+
+@router.post('/', response_model=SecurityOtherRead)
+def create_security_other(data: SecurityOtherCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=SecurityOtherRead)
+def read_security_other(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="SecurityOther not found")
+    return obj
+
+@router.get('/', response_model=list[SecurityOtherRead])
+def read_security_others(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=SecurityOtherRead)
+def update_security_other(obj_id: uuid.UUID, data: SecurityOtherCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="SecurityOther not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_security_other(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="SecurityOther not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/suggested_reference.py
+++ b/backend/app/routes/suggested_reference.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import suggested_reference as crud
+from ..schemas import SuggestedReferenceCreate, SuggestedReferenceRead
+
+router = APIRouter(prefix="/suggested_references", tags=["SuggestedReference"])
+
+@router.post('/', response_model=SuggestedReferenceRead)
+def create_suggested_reference(data: SuggestedReferenceCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=SuggestedReferenceRead)
+def read_suggested_reference(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="SuggestedReference not found")
+    return obj
+
+@router.get('/', response_model=list[SuggestedReferenceRead])
+def read_suggested_references(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=SuggestedReferenceRead)
+def update_suggested_reference(obj_id: uuid.UUID, data: SuggestedReferenceCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="SuggestedReference not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_suggested_reference(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="SuggestedReference not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/supervisor.py
+++ b/backend/app/routes/supervisor.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import supervisor as crud
+from ..schemas import SupervisorCreate, SupervisorRead
+
+router = APIRouter(prefix="/supervisors", tags=["Supervisor"])
+
+@router.post('/', response_model=SupervisorRead)
+def create_supervisor(data: SupervisorCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=SupervisorRead)
+def read_supervisor(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Supervisor not found")
+    return obj
+
+@router.get('/', response_model=list[SupervisorRead])
+def read_supervisors(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=SupervisorRead)
+def update_supervisor(obj_id: uuid.UUID, data: SupervisorCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Supervisor not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_supervisor(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Supervisor not found")
+    crud.delete(db, obj)
+    return {'ok': True}

--- a/backend/app/routes/user.py
+++ b/backend/app/routes/user.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..crud import user as crud
+from ..schemas import UserCreate, UserRead
+
+router = APIRouter(prefix="/users", tags=["User"])
+
+@router.post('/', response_model=UserRead)
+def create_user(data: UserCreate, db: Session = Depends(get_db)):
+    return crud.create(db, data.dict())
+
+@router.get('/{obj_id}', response_model=UserRead)
+def read_user(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="User not found")
+    return obj
+
+@router.get('/', response_model=list[UserRead])
+def read_users(db: Session = Depends(get_db)):
+    return list(crud.get_all(db))
+
+@router.put('/{obj_id}', response_model=UserRead)
+def update_user(obj_id: uuid.UUID, data: UserCreate, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="User not found")
+    return crud.update(db, obj, data.dict())
+
+@router.delete('/{obj_id}')
+def delete_user(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+    obj = crud.get_by_id(db, obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="User not found")
+    crud.delete(db, obj)
+    return {'ok': True}


### PR DESCRIPTION
## Summary
- expose CRUD routes per model in `routes/`
- collect all routers in `routes/__init__`
- include all API routers in FastAPI app

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68507c6bc1e4832ca5724c21935a41bb