### PR TITLE
Add soft delete support across models

### DIFF
--- a/backend/app/crud/academic_portfolio.py
+++ b/backend/app/crud/academic_portfolio.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> AcademicPortfolio:
     return _create(db, AcademicPortfolio, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, AcademicPortfolio, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, AcademicPortfolio, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, AcademicPortfolio)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, AcademicPortfolio, include_deleted)
 
 
 def update(db: Session, obj: AcademicPortfolio, data: dict) -> AcademicPortfolio:
@@ -24,5 +24,5 @@ def delete(db: Session, obj: AcademicPortfolio) -> None:
     _delete(db, obj)
 
 
-def get_academic_portfolios_by_application_form_id(db: Session, application_form_id: str):
-    return get_all_by_field(db, AcademicPortfolio, 'application_form_id', application_form_id)
+def get_academic_portfolios_by_application_form_id(db: Session, application_form_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, AcademicPortfolio, 'application_form_id', application_form_id, include_deleted)

--- a/backend/app/crud/academic_reference.py
+++ b/backend/app/crud/academic_reference.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> AcademicReference:
     return _create(db, AcademicReference, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, AcademicReference, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, AcademicReference, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, AcademicReference)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, AcademicReference, include_deleted)
 
 
 def update(db: Session, obj: AcademicReference, data: dict) -> AcademicReference:
@@ -24,5 +24,5 @@ def delete(db: Session, obj: AcademicReference) -> None:
     _delete(db, obj)
 
 
-def get_academic_references_by_application_form_id(db: Session, application_form_id: str):
-    return get_all_by_field(db, AcademicReference, 'application_form_id', application_form_id)
+def get_academic_references_by_application_form_id(db: Session, application_form_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, AcademicReference, 'application_form_id', application_form_id, include_deleted)

--- a/backend/app/crud/application.py
+++ b/backend/app/crud/application.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> Application:
     return _create(db, Application, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, Application, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, Application, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, Application)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, Application, include_deleted)
 
 
 def update(db: Session, obj: Application, data: dict) -> Application:
@@ -24,9 +24,9 @@ def delete(db: Session, obj: Application) -> None:
     _delete(db, obj)
 
 
-def get_applications_by_call_id(db: Session, call_id: str):
-    return get_all_by_field(db, Application, 'call_id', call_id)
+def get_applications_by_call_id(db: Session, call_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, Application, 'call_id', call_id, include_deleted)
 
 
-def get_applications_by_user_id(db: Session, user_id: str):
-    return get_all_by_field(db, Application, 'user_id', user_id)
+def get_applications_by_user_id(db: Session, user_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, Application, 'user_id', user_id, include_deleted)

--- a/backend/app/crud/application_form.py
+++ b/backend/app/crud/application_form.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> ApplicationForm:
     return _create(db, ApplicationForm, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, ApplicationForm, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, ApplicationForm, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, ApplicationForm)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, ApplicationForm, include_deleted)
 
 
 def update(db: Session, obj: ApplicationForm, data: dict) -> ApplicationForm:
@@ -24,5 +24,5 @@ def delete(db: Session, obj: ApplicationForm) -> None:
     _delete(db, obj)
 
 
-def get_application_forms_by_application_id(db: Session, application_id: str):
-    return get_all_by_field(db, ApplicationForm, 'application_id', application_id)
+def get_application_forms_by_application_id(db: Session, application_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, ApplicationForm, 'application_id', application_id, include_deleted)

--- a/backend/app/crud/application_info.py
+++ b/backend/app/crud/application_info.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> ApplicationInfo:
     return _create(db, ApplicationInfo, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, ApplicationInfo, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, ApplicationInfo, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, ApplicationInfo)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, ApplicationInfo, include_deleted)
 
 
 def update(db: Session, obj: ApplicationInfo, data: dict) -> ApplicationInfo:
@@ -24,5 +24,5 @@ def delete(db: Session, obj: ApplicationInfo) -> None:
     _delete(db, obj)
 
 
-def get_application_infos_by_application_id(db: Session, application_id: str):
-    return get_all_by_field(db, ApplicationInfo, 'application_id', application_id)
+def get_application_infos_by_application_id(db: Session, application_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, ApplicationInfo, 'application_id', application_id, include_deleted)

--- a/backend/app/crud/attachment.py
+++ b/backend/app/crud/attachment.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> Attachment:
     return _create(db, Attachment, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, Attachment, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, Attachment, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, Attachment)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, Attachment, include_deleted)
 
 
 def update(db: Session, obj: Attachment, data: dict) -> Attachment:
@@ -24,5 +24,5 @@ def delete(db: Session, obj: Attachment) -> None:
     _delete(db, obj)
 
 
-def get_attachments_by_application_id(db: Session, application_id: str):
-    return get_all_by_field(db, Attachment, 'application_id', application_id)
+def get_attachments_by_application_id(db: Session, application_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, Attachment, 'application_id', application_id, include_deleted)

--- a/backend/app/crud/call.py
+++ b/backend/app/crud/call.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> Call:
     return _create(db, Call, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, Call, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, Call, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, Call)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, Call, include_deleted)
 
 
 def update(db: Session, obj: Call, data: dict) -> Call:

--- a/backend/app/crud/call_ethics_question.py
+++ b/backend/app/crud/call_ethics_question.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> CallEthicsQuestion:
     return _create(db, CallEthicsQuestion, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, CallEthicsQuestion, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, CallEthicsQuestion, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, CallEthicsQuestion)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, CallEthicsQuestion, include_deleted)
 
 
 def update(db: Session, obj: CallEthicsQuestion, data: dict) -> CallEthicsQuestion:
@@ -24,5 +24,5 @@ def delete(db: Session, obj: CallEthicsQuestion) -> None:
     _delete(db, obj)
 
 
-def get_call_ethics_questions_by_call_id(db: Session, call_id: str):
-    return get_all_by_field(db, CallEthicsQuestion, 'call_id', call_id)
+def get_call_ethics_questions_by_call_id(db: Session, call_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, CallEthicsQuestion, 'call_id', call_id, include_deleted)

--- a/backend/app/crud/call_institution.py
+++ b/backend/app/crud/call_institution.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> CallInstitution:
     return _create(db, CallInstitution, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, CallInstitution, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, CallInstitution, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, CallInstitution)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, CallInstitution, include_deleted)
 
 
 def update(db: Session, obj: CallInstitution, data: dict) -> CallInstitution:
@@ -24,9 +24,9 @@ def delete(db: Session, obj: CallInstitution) -> None:
     _delete(db, obj)
 
 
-def get_call_institutions_by_call_id(db: Session, call_id: str):
-    return get_all_by_field(db, CallInstitution, 'call_id', call_id)
+def get_call_institutions_by_call_id(db: Session, call_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, CallInstitution, 'call_id', call_id, include_deleted)
 
 
-def get_call_institutions_by_institution_id(db: Session, institution_id: str):
-    return get_all_by_field(db, CallInstitution, 'institution_id', institution_id)
+def get_call_institutions_by_institution_id(db: Session, institution_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, CallInstitution, 'institution_id', institution_id, include_deleted)

--- a/backend/app/crud/call_required_document.py
+++ b/backend/app/crud/call_required_document.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> CallRequiredDocument:
     return _create(db, CallRequiredDocument, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, CallRequiredDocument, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, CallRequiredDocument, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, CallRequiredDocument)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, CallRequiredDocument, include_deleted)
 
 
 def update(db: Session, obj: CallRequiredDocument, data: dict) -> CallRequiredDocument:
@@ -24,5 +24,5 @@ def delete(db: Session, obj: CallRequiredDocument) -> None:
     _delete(db, obj)
 
 
-def get_call_required_documents_by_call_id(db: Session, call_id: str):
-    return get_all_by_field(db, CallRequiredDocument, 'call_id', call_id)
+def get_call_required_documents_by_call_id(db: Session, call_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, CallRequiredDocument, 'call_id', call_id, include_deleted)

--- a/backend/app/crud/call_security_question.py
+++ b/backend/app/crud/call_security_question.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> CallSecurityQuestion:
     return _create(db, CallSecurityQuestion, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, CallSecurityQuestion, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, CallSecurityQuestion, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, CallSecurityQuestion)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, CallSecurityQuestion, include_deleted)
 
 
 def update(db: Session, obj: CallSecurityQuestion, data: dict) -> CallSecurityQuestion:
@@ -24,5 +24,5 @@ def delete(db: Session, obj: CallSecurityQuestion) -> None:
     _delete(db, obj)
 
 
-def get_call_security_questions_by_call_id(db: Session, call_id: str):
-    return get_all_by_field(db, CallSecurityQuestion, 'call_id', call_id)
+def get_call_security_questions_by_call_id(db: Session, call_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, CallSecurityQuestion, 'call_id', call_id, include_deleted)

--- a/backend/app/crud/call_supervisor.py
+++ b/backend/app/crud/call_supervisor.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> CallSupervisor:
     return _create(db, CallSupervisor, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, CallSupervisor, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, CallSupervisor, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, CallSupervisor)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, CallSupervisor, include_deleted)
 
 
 def update(db: Session, obj: CallSupervisor, data: dict) -> CallSupervisor:
@@ -24,9 +24,9 @@ def delete(db: Session, obj: CallSupervisor) -> None:
     _delete(db, obj)
 
 
-def get_call_supervisors_by_call_id(db: Session, call_id: str):
-    return get_all_by_field(db, CallSupervisor, 'call_id', call_id)
+def get_call_supervisors_by_call_id(db: Session, call_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, CallSupervisor, 'call_id', call_id, include_deleted)
 
 
-def get_call_supervisors_by_supervisor_id(db: Session, supervisor_id: str):
-    return get_all_by_field(db, CallSupervisor, 'supervisor_id', supervisor_id)
+def get_call_supervisors_by_supervisor_id(db: Session, supervisor_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, CallSupervisor, 'supervisor_id', supervisor_id, include_deleted)

--- a/backend/app/crud/call_template.py
+++ b/backend/app/crud/call_template.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> CallTemplate:
     return _create(db, CallTemplate, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, CallTemplate, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, CallTemplate, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, CallTemplate)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, CallTemplate, include_deleted)
 
 
 def update(db: Session, obj: CallTemplate, data: dict) -> CallTemplate:
@@ -24,5 +24,5 @@ def delete(db: Session, obj: CallTemplate) -> None:
     _delete(db, obj)
 
 
-def get_call_templates_by_call_id(db: Session, call_id: str):
-    return get_all_by_field(db, CallTemplate, 'call_id', call_id)
+def get_call_templates_by_call_id(db: Session, call_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, CallTemplate, 'call_id', call_id, include_deleted)

--- a/backend/app/crud/ethical_optional_table.py
+++ b/backend/app/crud/ethical_optional_table.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> EthicalOptionalTable:
     return _create(db, EthicalOptionalTable, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, EthicalOptionalTable, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, EthicalOptionalTable, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, EthicalOptionalTable)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, EthicalOptionalTable, include_deleted)
 
 
 def update(db: Session, obj: EthicalOptionalTable, data: dict) -> EthicalOptionalTable:
@@ -24,5 +24,5 @@ def delete(db: Session, obj: EthicalOptionalTable) -> None:
     _delete(db, obj)
 
 
-def get_ethical_optional_tables_by_application_form_id(db: Session, application_form_id: str):
-    return get_all_by_field(db, EthicalOptionalTable, 'application_form_id', application_form_id)
+def get_ethical_optional_tables_by_application_form_id(db: Session, application_form_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, EthicalOptionalTable, 'application_form_id', application_form_id, include_deleted)

--- a/backend/app/crud/ethics_answer.py
+++ b/backend/app/crud/ethics_answer.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> EthicsAnswer:
     return _create(db, EthicsAnswer, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, EthicsAnswer, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, EthicsAnswer, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, EthicsAnswer)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, EthicsAnswer, include_deleted)
 
 
 def update(db: Session, obj: EthicsAnswer, data: dict) -> EthicsAnswer:
@@ -24,5 +24,5 @@ def delete(db: Session, obj: EthicsAnswer) -> None:
     _delete(db, obj)
 
 
-def get_ethics_answers_by_application_form_id(db: Session, application_form_id: str):
-    return get_all_by_field(db, EthicsAnswer, 'application_form_id', application_form_id)
+def get_ethics_answers_by_application_form_id(db: Session, application_form_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, EthicsAnswer, 'application_form_id', application_form_id, include_deleted)

--- a/backend/app/crud/ethics_issue.py
+++ b/backend/app/crud/ethics_issue.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> EthicsIssue:
     return _create(db, EthicsIssue, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, EthicsIssue, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, EthicsIssue, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, EthicsIssue)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, EthicsIssue, include_deleted)
 
 
 def update(db: Session, obj: EthicsIssue, data: dict) -> EthicsIssue:
@@ -24,9 +24,9 @@ def delete(db: Session, obj: EthicsIssue) -> None:
     _delete(db, obj)
 
 
-def get_ethics_issues_by_application_form_id(db: Session, application_form_id: str):
-    return get_all_by_field(db, EthicsIssue, 'application_form_id', application_form_id)
+def get_ethics_issues_by_application_form_id(db: Session, application_form_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, EthicsIssue, 'application_form_id', application_form_id, include_deleted)
 
 
-def get_ethics_issues_by_meta_id(db: Session, meta_id: str):
-    return get_all_by_field(db, EthicsIssue, 'meta_id', meta_id)
+def get_ethics_issues_by_meta_id(db: Session, meta_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, EthicsIssue, 'meta_id', meta_id, include_deleted)

--- a/backend/app/crud/ethics_meta.py
+++ b/backend/app/crud/ethics_meta.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> EthicsMeta:
     return _create(db, EthicsMeta, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, EthicsMeta, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, EthicsMeta, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, EthicsMeta)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, EthicsMeta, include_deleted)
 
 
 def update(db: Session, obj: EthicsMeta, data: dict) -> EthicsMeta:

--- a/backend/app/crud/institution.py
+++ b/backend/app/crud/institution.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> Institution:
     return _create(db, Institution, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, Institution, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, Institution, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, Institution)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, Institution, include_deleted)
 
 
 def update(db: Session, obj: Institution, data: dict) -> Institution:

--- a/backend/app/crud/mobility_entry.py
+++ b/backend/app/crud/mobility_entry.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> MobilityEntry:
     return _create(db, MobilityEntry, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, MobilityEntry, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, MobilityEntry, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, MobilityEntry)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, MobilityEntry, include_deleted)
 
 
 def update(db: Session, obj: MobilityEntry, data: dict) -> MobilityEntry:
@@ -24,5 +24,5 @@ def delete(db: Session, obj: MobilityEntry) -> None:
     _delete(db, obj)
 
 
-def get_mobility_entries_by_application_form_id(db: Session, application_form_id: str):
-    return get_all_by_field(db, MobilityEntry, 'application_form_id', application_form_id)
+def get_mobility_entries_by_application_form_id(db: Session, application_form_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, MobilityEntry, 'application_form_id', application_form_id, include_deleted)

--- a/backend/app/crud/review_report.py
+++ b/backend/app/crud/review_report.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> ReviewReport:
     return _create(db, ReviewReport, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, ReviewReport, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, ReviewReport, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, ReviewReport)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, ReviewReport, include_deleted)
 
 
 def update(db: Session, obj: ReviewReport, data: dict) -> ReviewReport:
@@ -24,13 +24,13 @@ def delete(db: Session, obj: ReviewReport) -> None:
     _delete(db, obj)
 
 
-def get_review_reports_by_call_id(db: Session, call_id: str):
-    return get_all_by_field(db, ReviewReport, 'call_id', call_id)
+def get_review_reports_by_call_id(db: Session, call_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, ReviewReport, 'call_id', call_id, include_deleted)
 
 
-def get_review_reports_by_application_id(db: Session, application_id: str):
-    return get_all_by_field(db, ReviewReport, 'application_id', application_id)
+def get_review_reports_by_application_id(db: Session, application_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, ReviewReport, 'application_id', application_id, include_deleted)
 
 
-def get_review_reports_by_reviewer_id(db: Session, reviewer_id: str):
-    return get_all_by_field(db, ReviewReport, 'reviewer_id', reviewer_id)
+def get_review_reports_by_reviewer_id(db: Session, reviewer_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, ReviewReport, 'reviewer_id', reviewer_id, include_deleted)

--- a/backend/app/crud/security_answer.py
+++ b/backend/app/crud/security_answer.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> SecurityAnswer:
     return _create(db, SecurityAnswer, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, SecurityAnswer, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, SecurityAnswer, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, SecurityAnswer)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, SecurityAnswer, include_deleted)
 
 
 def update(db: Session, obj: SecurityAnswer, data: dict) -> SecurityAnswer:
@@ -24,5 +24,5 @@ def delete(db: Session, obj: SecurityAnswer) -> None:
     _delete(db, obj)
 
 
-def get_security_answers_by_application_form_id(db: Session, application_form_id: str):
-    return get_all_by_field(db, SecurityAnswer, 'application_form_id', application_form_id)
+def get_security_answers_by_application_form_id(db: Session, application_form_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, SecurityAnswer, 'application_form_id', application_form_id, include_deleted)

--- a/backend/app/crud/security_euci.py
+++ b/backend/app/crud/security_euci.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> SecurityEuci:
     return _create(db, SecurityEuci, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, SecurityEuci, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, SecurityEuci, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, SecurityEuci)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, SecurityEuci, include_deleted)
 
 
 def update(db: Session, obj: SecurityEuci, data: dict) -> SecurityEuci:
@@ -24,5 +24,5 @@ def delete(db: Session, obj: SecurityEuci) -> None:
     _delete(db, obj)
 
 
-def get_security_eucis_by_application_form_id(db: Session, application_form_id: str):
-    return get_all_by_field(db, SecurityEuci, 'application_form_id', application_form_id)
+def get_security_eucis_by_application_form_id(db: Session, application_form_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, SecurityEuci, 'application_form_id', application_form_id, include_deleted)

--- a/backend/app/crud/security_meta.py
+++ b/backend/app/crud/security_meta.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> SecurityMeta:
     return _create(db, SecurityMeta, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, SecurityMeta, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, SecurityMeta, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, SecurityMeta)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, SecurityMeta, include_deleted)
 
 
 def update(db: Session, obj: SecurityMeta, data: dict) -> SecurityMeta:

--- a/backend/app/crud/security_misuse.py
+++ b/backend/app/crud/security_misuse.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> SecurityMisuse:
     return _create(db, SecurityMisuse, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, SecurityMisuse, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, SecurityMisuse, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, SecurityMisuse)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, SecurityMisuse, include_deleted)
 
 
 def update(db: Session, obj: SecurityMisuse, data: dict) -> SecurityMisuse:
@@ -24,5 +24,5 @@ def delete(db: Session, obj: SecurityMisuse) -> None:
     _delete(db, obj)
 
 
-def get_security_misuses_by_application_form_id(db: Session, application_form_id: str):
-    return get_all_by_field(db, SecurityMisuse, 'application_form_id', application_form_id)
+def get_security_misuses_by_application_form_id(db: Session, application_form_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, SecurityMisuse, 'application_form_id', application_form_id, include_deleted)

--- a/backend/app/crud/security_other.py
+++ b/backend/app/crud/security_other.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> SecurityOther:
     return _create(db, SecurityOther, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, SecurityOther, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, SecurityOther, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, SecurityOther)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, SecurityOther, include_deleted)
 
 
 def update(db: Session, obj: SecurityOther, data: dict) -> SecurityOther:
@@ -24,5 +24,5 @@ def delete(db: Session, obj: SecurityOther) -> None:
     _delete(db, obj)
 
 
-def get_security_others_by_application_form_id(db: Session, application_form_id: str):
-    return get_all_by_field(db, SecurityOther, 'application_form_id', application_form_id)
+def get_security_others_by_application_form_id(db: Session, application_form_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, SecurityOther, 'application_form_id', application_form_id, include_deleted)

--- a/backend/app/crud/suggested_reference.py
+++ b/backend/app/crud/suggested_reference.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> SuggestedReference:
     return _create(db, SuggestedReference, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, SuggestedReference, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, SuggestedReference, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, SuggestedReference)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, SuggestedReference, include_deleted)
 
 
 def update(db: Session, obj: SuggestedReference, data: dict) -> SuggestedReference:
@@ -24,5 +24,5 @@ def delete(db: Session, obj: SuggestedReference) -> None:
     _delete(db, obj)
 
 
-def get_suggested_references_by_application_form_id(db: Session, application_form_id: str):
-    return get_all_by_field(db, SuggestedReference, 'application_form_id', application_form_id)
+def get_suggested_references_by_application_form_id(db: Session, application_form_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, SuggestedReference, 'application_form_id', application_form_id, include_deleted)

--- a/backend/app/crud/supervisor.py
+++ b/backend/app/crud/supervisor.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> Supervisor:
     return _create(db, Supervisor, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, Supervisor, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, Supervisor, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, Supervisor)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, Supervisor, include_deleted)
 
 
 def update(db: Session, obj: Supervisor, data: dict) -> Supervisor:
@@ -24,5 +24,5 @@ def delete(db: Session, obj: Supervisor) -> None:
     _delete(db, obj)
 
 
-def get_supervisors_by_institution_id(db: Session, institution_id: str):
-    return get_all_by_field(db, Supervisor, 'institution_id', institution_id)
+def get_supervisors_by_institution_id(db: Session, institution_id: str, include_deleted: bool = False):
+    return get_all_by_field(db, Supervisor, 'institution_id', institution_id, include_deleted)

--- a/backend/app/crud/user.py
+++ b/backend/app/crud/user.py
@@ -8,12 +8,12 @@ def create(db: Session, data: dict) -> User:
     return _create(db, User, data)
 
 
-def get_by_id(db: Session, obj_id):
-    return _get_by_id(db, User, obj_id)
+def get_by_id(db: Session, obj_id, include_deleted: bool = False):
+    return _get_by_id(db, User, obj_id, include_deleted)
 
 
-def get_all(db: Session):
-    return _get_all(db, User)
+def get_all(db: Session, include_deleted: bool = False):
+    return _get_all(db, User, include_deleted)
 
 
 def update(db: Session, obj: User, data: dict) -> User:

--- a/backend/app/models/academic_portfolio.py
+++ b/backend/app/models/academic_portfolio.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class AcademicPortfolio(Base):
+class AcademicPortfolio(Base, SoftDeleteMixin):
     __tablename__ = 'academic_portfolio'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     application_form_id = Column(UUID(as_uuid=True), ForeignKey('application_forms.id', ondelete='CASCADE'))

--- a/backend/app/models/academic_reference.py
+++ b/backend/app/models/academic_reference.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class AcademicReference(Base):
+class AcademicReference(Base, SoftDeleteMixin):
     __tablename__ = 'academic_references'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     application_form_id = Column(UUID(as_uuid=True), ForeignKey('application_forms.id', ondelete='CASCADE'))

--- a/backend/app/models/application.py
+++ b/backend/app/models/application.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class Application(Base):
+class Application(Base, SoftDeleteMixin):
     __tablename__ = 'applications'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     call_id = Column(UUID(as_uuid=True), ForeignKey('calls.id', ondelete='CASCADE'))

--- a/backend/app/models/application_form.py
+++ b/backend/app/models/application_form.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class ApplicationForm(Base):
+class ApplicationForm(Base, SoftDeleteMixin):
     __tablename__ = 'application_forms'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     application_id = Column(UUID(as_uuid=True), ForeignKey('applications.id', ondelete='CASCADE'), unique=True)

--- a/backend/app/models/application_info.py
+++ b/backend/app/models/application_info.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class ApplicationInfo(Base):
+class ApplicationInfo(Base, SoftDeleteMixin):
     __tablename__ = 'application_info'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     application_id = Column(UUID(as_uuid=True), ForeignKey('applications.id', ondelete='CASCADE'), unique=True)

--- a/backend/app/models/attachment.py
+++ b/backend/app/models/attachment.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class Attachment(Base):
+class Attachment(Base, SoftDeleteMixin):
     __tablename__ = 'attachments'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     application_id = Column(UUID(as_uuid=True), ForeignKey('applications.id', ondelete='CASCADE'))

--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -24,9 +24,15 @@ from sqlalchemy.orm import relationship
 from ..database import Base
 from ..core.enums import UserRole, CallStatus, ApplicationStatus
 
+
+class SoftDeleteMixin:
+    """Mixin providing soft delete support."""
+
+    is_deleted = Column(Boolean, default=False)
+
 __all__ = [
     'uuid', 'datetime', 'date', 'Column', 'String', 'Text', 'Boolean', 'Integer',
     'Date', 'DateTime', 'ForeignKey', 'SAEnum', 'JSON', 'Numeric', 'SmallInteger',
     'LargeBinary', 'UUID', 'relationship', 'Base',
-    'UserRole', 'CallStatus', 'ApplicationStatus'
+    'UserRole', 'CallStatus', 'ApplicationStatus', 'SoftDeleteMixin'
 ]

--- a/backend/app/models/call.py
+++ b/backend/app/models/call.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class Call(Base):
+class Call(Base, SoftDeleteMixin):
     __tablename__ = 'calls'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     title = Column(String(255), nullable=False)

--- a/backend/app/models/call_ethics_question.py
+++ b/backend/app/models/call_ethics_question.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class CallEthicsQuestion(Base):
+class CallEthicsQuestion(Base, SoftDeleteMixin):
     __tablename__ = 'call_ethics_questions'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     call_id = Column(UUID(as_uuid=True), ForeignKey('calls.id', ondelete='CASCADE'))

--- a/backend/app/models/call_institution.py
+++ b/backend/app/models/call_institution.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class CallInstitution(Base):
+class CallInstitution(Base, SoftDeleteMixin):
     __tablename__ = 'call_institutions'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     call_id = Column(UUID(as_uuid=True), ForeignKey('calls.id', ondelete='CASCADE'))

--- a/backend/app/models/call_required_document.py
+++ b/backend/app/models/call_required_document.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class CallRequiredDocument(Base):
+class CallRequiredDocument(Base, SoftDeleteMixin):
     __tablename__ = 'call_required_documents'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     call_id = Column(UUID(as_uuid=True), ForeignKey('calls.id', ondelete='CASCADE'))

--- a/backend/app/models/call_security_question.py
+++ b/backend/app/models/call_security_question.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class CallSecurityQuestion(Base):
+class CallSecurityQuestion(Base, SoftDeleteMixin):
     __tablename__ = 'call_security_questions'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     call_id = Column(UUID(as_uuid=True), ForeignKey('calls.id', ondelete='CASCADE'))

--- a/backend/app/models/call_supervisor.py
+++ b/backend/app/models/call_supervisor.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class CallSupervisor(Base):
+class CallSupervisor(Base, SoftDeleteMixin):
     __tablename__ = 'call_supervisors'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     call_id = Column(UUID(as_uuid=True), ForeignKey('calls.id', ondelete='CASCADE'))

--- a/backend/app/models/call_template.py
+++ b/backend/app/models/call_template.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class CallTemplate(Base):
+class CallTemplate(Base, SoftDeleteMixin):
     __tablename__ = 'call_templates'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     call_id = Column(UUID(as_uuid=True), ForeignKey('calls.id', ondelete='CASCADE'))

--- a/backend/app/models/ethical_optional_table.py
+++ b/backend/app/models/ethical_optional_table.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class EthicalOptionalTable(Base):
+class EthicalOptionalTable(Base, SoftDeleteMixin):
     __tablename__ = 'ethical_optional_tables'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     application_form_id = Column(UUID(as_uuid=True), ForeignKey('application_forms.id', ondelete='CASCADE'))

--- a/backend/app/models/ethics_answer.py
+++ b/backend/app/models/ethics_answer.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class EthicsAnswer(Base):
+class EthicsAnswer(Base, SoftDeleteMixin):
     __tablename__ = 'ethics_answers'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     application_form_id = Column(UUID(as_uuid=True), ForeignKey('application_forms.id', ondelete='CASCADE'))

--- a/backend/app/models/ethics_issue.py
+++ b/backend/app/models/ethics_issue.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class EthicsIssue(Base):
+class EthicsIssue(Base, SoftDeleteMixin):
     __tablename__ = 'ethics_issues'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     application_form_id = Column(UUID(as_uuid=True), ForeignKey('application_forms.id', ondelete='CASCADE'))

--- a/backend/app/models/ethics_meta.py
+++ b/backend/app/models/ethics_meta.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class EthicsMeta(Base):
+class EthicsMeta(Base, SoftDeleteMixin):
     __tablename__ = 'ethics_meta'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     category = Column(String(100))

--- a/backend/app/models/institution.py
+++ b/backend/app/models/institution.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class Institution(Base):
+class Institution(Base, SoftDeleteMixin):
     __tablename__ = 'institutions'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = Column(String(255), nullable=False)

--- a/backend/app/models/mobility_entry.py
+++ b/backend/app/models/mobility_entry.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class MobilityEntry(Base):
+class MobilityEntry(Base, SoftDeleteMixin):
     __tablename__ = 'mobility_entries'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     application_form_id = Column(UUID(as_uuid=True), ForeignKey('application_forms.id', ondelete='CASCADE'))

--- a/backend/app/models/review_report.py
+++ b/backend/app/models/review_report.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class ReviewReport(Base):
+class ReviewReport(Base, SoftDeleteMixin):
     __tablename__ = 'review_reports'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     call_id = Column(UUID(as_uuid=True), ForeignKey('calls.id', ondelete='CASCADE'))

--- a/backend/app/models/security_answer.py
+++ b/backend/app/models/security_answer.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class SecurityAnswer(Base):
+class SecurityAnswer(Base, SoftDeleteMixin):
     __tablename__ = 'security_answers'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     application_form_id = Column(UUID(as_uuid=True), ForeignKey('application_forms.id', ondelete='CASCADE'))

--- a/backend/app/models/security_euci.py
+++ b/backend/app/models/security_euci.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class SecurityEUCI(Base):
+class SecurityEUCI(Base, SoftDeleteMixin):
     __tablename__ = 'security_euci'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     application_form_id = Column(UUID(as_uuid=True), ForeignKey('application_forms.id', ondelete='CASCADE'))

--- a/backend/app/models/security_meta.py
+++ b/backend/app/models/security_meta.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class SecurityMeta(Base):
+class SecurityMeta(Base, SoftDeleteMixin):
     __tablename__ = 'security_meta'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     category = Column(String(100))

--- a/backend/app/models/security_misuse.py
+++ b/backend/app/models/security_misuse.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class SecurityMisuse(Base):
+class SecurityMisuse(Base, SoftDeleteMixin):
     __tablename__ = 'security_misuse'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     application_form_id = Column(UUID(as_uuid=True), ForeignKey('application_forms.id', ondelete='CASCADE'))

--- a/backend/app/models/security_other.py
+++ b/backend/app/models/security_other.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class SecurityOther(Base):
+class SecurityOther(Base, SoftDeleteMixin):
     __tablename__ = 'security_other'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     application_form_id = Column(UUID(as_uuid=True), ForeignKey('application_forms.id', ondelete='CASCADE'))

--- a/backend/app/models/suggested_reference.py
+++ b/backend/app/models/suggested_reference.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class SuggestedReference(Base):
+class SuggestedReference(Base, SoftDeleteMixin):
     __tablename__ = 'suggested_references'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     application_form_id = Column(UUID(as_uuid=True), ForeignKey('application_forms.id', ondelete='CASCADE'))

--- a/backend/app/models/supervisor.py
+++ b/backend/app/models/supervisor.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class Supervisor(Base):
+class Supervisor(Base, SoftDeleteMixin):
     __tablename__ = 'supervisors'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     institution_id = Column(UUID(as_uuid=True), ForeignKey('institutions.id'))

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,6 +1,6 @@
 from .base import *
 
-class User(Base):
+class User(Base, SoftDeleteMixin):
     __tablename__ = 'users'
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     email = Column(String(255), unique=True, nullable=False)


### PR DESCRIPTION
## Summary
- introduce `SoftDeleteMixin` for models
- add `include_deleted` support in CRUD operations
- implement soft delete logic in base CRUD
- update models to inherit soft delete functionality

## Testing
- `python -m compileall backend/app`

------
https://chatgpt.com/codex/tasks/task_e_68507f650d78832c8ea40ab64fd9b5ba