### PR TITLE
Add file upload service and API

### DIFF
--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -27,6 +27,7 @@ from . import (
     suggested_reference,
     supervisor,
     user,
+    file,
 )
 
 from fastapi import APIRouter
@@ -61,5 +62,6 @@ api_router.include_router(security_other.router)
 api_router.include_router(suggested_reference.router)
 api_router.include_router(supervisor.router)
 api_router.include_router(user.router)
+api_router.include_router(file.router)
 
 __all__ = ["api_router"]

--- a/backend/app/routes/file.py
+++ b/backend/app/routes/file.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, Depends, File, UploadFile, Response
+from sqlalchemy.orm import Session
+import uuid
+
+from ..database import get_db
+from ..services import file_service
+
+router = APIRouter(tags=["File"])
+
+
+@router.post("/applications/{application_id}/upload_file")
+def upload_file(
+    application_id: uuid.UUID,
+    upload: UploadFile = File(...),
+    db: Session = Depends(get_db),
+):
+    return file_service.save_attachment_file(db, application_id, upload)
+
+
+@router.get("/files/{attachment_id}")
+def get_file(
+    attachment_id: uuid.UUID,
+    db: Session = Depends(get_db),
+):
+    filename, data = file_service.get_attachment_file(db, attachment_id)
+    headers = {"Content-Disposition": f'attachment; filename="{filename}"'}
+    return Response(
+        content=data, media_type="application/octet-stream", headers=headers
+    )

--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -1,0 +1,40 @@
+# Service utilities for handling file uploads
+from __future__ import annotations
+
+from fastapi import HTTPException, UploadFile
+from sqlalchemy.orm import Session
+import uuid
+
+from .. import crud
+
+ALLOWED_MIME_TYPES = {"application/pdf", "image/jpeg", "image/png"}
+
+
+def validate_mime_type(upload_file: UploadFile) -> None:
+    """Ensure uploaded file is a supported type."""
+    if upload_file.content_type not in ALLOWED_MIME_TYPES:
+        raise HTTPException(status_code=400, detail="Unsupported file type")
+
+
+def save_attachment_file(
+    db: Session, application_id: uuid.UUID, upload_file: UploadFile
+):
+    """Create an Attachment and store the binary data."""
+    validate_mime_type(upload_file)
+    data = {
+        "application_id": application_id,
+        "doc_name": upload_file.filename,
+        "file_path": upload_file.filename,
+    }
+    attachment = crud.attachment.create(db, data)
+    attachment.file_blob = upload_file.file.read()
+    db.commit()
+    db.refresh(attachment)
+    return attachment
+
+
+def get_attachment_file(db: Session, attachment_id: uuid.UUID) -> tuple[str, bytes]:
+    attachment = crud.attachment.get_by_id(db, attachment_id)
+    if not attachment:
+        raise HTTPException(status_code=404, detail="File not found")
+    return attachment.doc_name or "file", attachment.file_blob


### PR DESCRIPTION
## Summary
- implement `file_service` for validating and storing binary uploads
- add `/applications/{id}/upload_file` and `/files/{id}` endpoints
- register new file routes

## Testing
- `python -m py_compile $(git ls-files "*.py")`

------
https://chatgpt.com/codex/tasks/task_e_68507f6b3c10832c8b858244e886704b