### PR TITLE
Add default security and file settings

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,2 +1,5 @@
 DATABASE_URL=postgresql://user:password@localhost:5432/dbname
 SECRET_KEY=change_me
+ALLOWED_MIME_TYPES=application/pdf
+ACCESS_TOKEN_EXPIRE_MINUTES=30
+ALGORITHM=HS256

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -3,6 +3,9 @@ from pydantic import BaseSettings
 class Settings(BaseSettings):
     DATABASE_URL: str
     SECRET_KEY: str
+    ALLOWED_MIME_TYPES: str = "application/pdf"
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
+    ALGORITHM: str = "HS256"
 
     class Config:
         env_file = '.env'


### PR DESCRIPTION
## Summary
- add new environment-driven settings in `config.py`
- extend example `.env` with defaults for the new settings

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68507f71dda4832ca19d3096212d07a0