### PR TITLE
Add authentication and admin route

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,2 +1,4 @@
 DATABASE_URL=postgresql://user:password@localhost:5432/dbname
 SECRET_KEY=change_me
+ACCESS_TOKEN_EXPIRE_MINUTES=60
+ALGORITHM=HS256

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -3,6 +3,8 @@ from pydantic import BaseSettings
 class Settings(BaseSettings):
     DATABASE_URL: str
     SECRET_KEY: str
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
+    ALGORITHM: str = "HS256"
 
     class Config:
         env_file = '.env'

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,0 +1,75 @@
+from datetime import datetime, timedelta
+from functools import wraps
+from inspect import iscoroutinefunction
+from typing import Callable
+
+from fastapi import Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from sqlalchemy.orm import Session
+
+from ..config import get_settings
+from ..crud import user as crud_user
+from ..database import get_db
+from ..models import User
+from .enums import UserRole
+
+settings = get_settings()
+
+ALGORITHM = settings.ALGORITHM
+ACCESS_TOKEN_EXPIRE_MINUTES = settings.ACCESS_TOKEN_EXPIRE_MINUTES
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = HTTPBearer()
+
+
+def hash_password(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def verify_password(password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(password, hashed_password)
+
+
+def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=ALGORITHM)
+
+
+def decode_access_token(token: str) -> dict:
+    try:
+        return jwt.decode(token, settings.SECRET_KEY, algorithms=[ALGORITHM])
+    except JWTError:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+
+
+def get_current_user(
+    db: Session = Depends(get_db),
+    credentials: HTTPAuthorizationCredentials = Depends(oauth2_scheme),
+) -> User:
+    payload = decode_access_token(credentials.credentials)
+    user_id = payload.get("sub")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    user = crud_user.get_by_id(db, user_id)
+    if not user:
+        raise HTTPException(status_code=401, detail="User not found")
+    return user
+
+
+def role_required(*roles: UserRole) -> Callable:
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        async def wrapper(*args, current_user: User = Depends(get_current_user), **kwargs):
+            if current_user.role not in roles:
+                raise HTTPException(status_code=403, detail="Forbidden")
+            if iscoroutinefunction(func):
+                return await func(*args, **kwargs)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/backend/app/crud/user.py
+++ b/backend/app/crud/user.py
@@ -22,3 +22,7 @@ def update(db: Session, obj: User, data: dict) -> User:
 
 def delete(db: Session, obj: User) -> None:
     _delete(db, obj)
+
+
+def get_by_email(db: Session, email: str) -> User | None:
+    return db.query(User).filter(User.email == email).first()

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -12,6 +12,8 @@ from . import (
     call_security_question,
     call_supervisor,
     call_template,
+    auth,
+    admin,
     ethical_optional_table,
     ethics_answer,
     ethics_issue,
@@ -61,5 +63,7 @@ api_router.include_router(security_other.router)
 api_router.include_router(suggested_reference.router)
 api_router.include_router(supervisor.router)
 api_router.include_router(user.router)
+api_router.include_router(auth.router)
+api_router.include_router(admin.router)
 
 __all__ = ["api_router"]

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from ..crud import call as crud_call
+from ..schemas import CallRead
+from ..core.security import role_required
+from ..core.enums import UserRole
+
+router = APIRouter(prefix="/admin", tags=["Admin"])
+
+
+@router.get("/calls", response_model=list[CallRead])
+@role_required(UserRole.admin, UserRole.super_admin)
+def list_calls(db: Session = Depends(get_db)):
+    return list(crud_call.get_all(db))

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -1,0 +1,33 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from ..crud import user as crud_user
+from ..schemas import UserCreate, UserRead
+from ..core.security import hash_password, verify_password, create_access_token
+
+router = APIRouter(prefix="/auth", tags=["Auth"])
+
+
+class LoginData(BaseModel):
+    email: str
+    password: str
+
+
+@router.post("/register", response_model=UserRead)
+def register(data: UserCreate, db: Session = Depends(get_db)):
+    if crud_user.get_by_email(db, data.email):
+        raise HTTPException(status_code=400, detail="Email already registered")
+    user_dict = data.dict()
+    user_dict["password_hash"] = hash_password(user_dict.pop("password"))
+    return crud_user.create(db, user_dict)
+
+
+@router.post("/login")
+def login(data: LoginData, db: Session = Depends(get_db)):
+    user = crud_user.get_by_email(db, data.email)
+    if not user or not verify_password(data.password, user.password_hash):
+        raise HTTPException(status_code=400, detail="Invalid credentials")
+    token = create_access_token({"sub": str(user.id), "role": user.role})
+    return {"access_token": token}

--- a/backend/app/routes/user.py
+++ b/backend/app/routes/user.py
@@ -5,6 +5,8 @@ import uuid
 from ..database import get_db
 from ..crud import user as crud
 from ..schemas import UserCreate, UserRead
+from ..core.security import role_required
+from ..core.enums import UserRole
 
 router = APIRouter(prefix="/users", tags=["User"])
 
@@ -20,6 +22,7 @@ def read_user(obj_id: uuid.UUID, db: Session = Depends(get_db)):
     return obj
 
 @router.get('/', response_model=list[UserRead])
+@role_required(UserRole.admin, UserRole.super_admin)
 def read_users(db: Session = Depends(get_db)):
     return list(crud.get_all(db))
 

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -26,6 +26,7 @@ from .security_other import SecurityOtherBase, SecurityOtherCreate, SecurityOthe
 from .suggested_reference import SuggestedReferenceBase, SuggestedReferenceCreate, SuggestedReferenceRead
 from .supervisor import SupervisorBase, SupervisorCreate, SupervisorRead
 from .user import UserBase, UserCreate, UserRead
+from .auth import Token, Login
 
 __all__ = [
     "AcademicPortfolioBase",
@@ -111,5 +112,7 @@ __all__ = [
     "SupervisorRead",
     "UserBase",
     "UserCreate",
-    "UserRead"
+    "UserRead",
+    "Token",
+    "Login"
 ]

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class Login(BaseModel):
+    email: str
+    password: str

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,6 @@ uvicorn
 sqlalchemy
 pydantic
 python-dotenv
+
+python-jose
+passlib[bcrypt]


### PR DESCRIPTION
## Summary
- add security helpers for hashing and JWT based auth
- expose register/login endpoints
- restrict user listing and add admin calls route
- provide auth models
- update dependencies
- load JWT settings from environment

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68507f6f69d0832cb54847d2f2054eca