### PR TITLE
Load MIME types from Settings

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,6 @@
 DATABASE_URL=postgresql://user:password@localhost:5432/dbname
 SECRET_KEY=change_me
 ACCESS_TOKEN_EXPIRE_MINUTES=60
-ALLOWED_MIME_TYPES=application/pdf
+# Comma-separated list of MIME types allowed for uploaded attachments
+ALLOWED_MIME_TYPES=application/pdf,image/jpeg,image/png
 ALGORITHM=HS256

--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -6,8 +6,12 @@ from sqlalchemy.orm import Session
 import uuid
 
 from .. import crud
+from ..config import get_settings
 
-ALLOWED_MIME_TYPES = {"application/pdf", "image/jpeg", "image/png"}
+settings = get_settings()
+
+# Supported MIME types configured via environment variable
+ALLOWED_MIME_TYPES = set(settings.ALLOWED_MIME_TYPES.split(","))
 
 
 def validate_mime_type(upload_file: UploadFile) -> None:


### PR DESCRIPTION
## Summary
- read allowed MIME types from the `Settings` object
- document allowed MIME types in `.env.example`

## Testing
- `python -m py_compile backend/app/services/file_service.py backend/app/config.py`


------
https://chatgpt.com/codex/tasks/task_e_6850873ceb2c832ca4bb860f7e6cc4ca