### PR TITLE
Restrict user update & delete routes

### DIFF
--- a/backend/app/routes/user.py
+++ b/backend/app/routes/user.py
@@ -30,6 +30,7 @@ def read_users(db: Session = Depends(get_db)):
     return list(crud.get_all(db))
 
 @router.put('/{obj_id}', response_model=UserRead)
+@role_required(UserRole.super_admin)
 def update_user(obj_id: uuid.UUID, data: UserCreate, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
@@ -37,6 +38,7 @@ def update_user(obj_id: uuid.UUID, data: UserCreate, db: Session = Depends(get_d
     return crud.update(db, obj, data.dict())
 
 @router.delete('/{obj_id}')
+@role_required(UserRole.super_admin)
 def delete_user(obj_id: uuid.UUID, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)
     if not obj:


### PR DESCRIPTION
## Summary
- limit update_user and delete_user endpoints to super admins

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68508b663e98832caf763e82647062bd