### PR TITLE
Restrict update and delete call endpoints

### DIFF
--- a/backend/app/routes/call.py
+++ b/backend/app/routes/call.py
@@ -5,6 +5,8 @@ import uuid
 from ..database import get_db
 from ..crud import call as crud
 from ..schemas import CallCreate, CallRead
+from ..core.security import role_required
+from ..core.enums import UserRole
 
 router = APIRouter(prefix="/calls", tags=["Call"])
 
@@ -24,6 +26,7 @@ def read_calls(db: Session = Depends(get_db)):
     return list(crud.get_all(db))
 
 @router.put('/{obj_id}', response_model=CallRead)
+@role_required(UserRole.super_admin)
 def update_call(obj_id: uuid.UUID, data: CallCreate, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
@@ -31,6 +34,7 @@ def update_call(obj_id: uuid.UUID, data: CallCreate, db: Session = Depends(get_d
     return crud.update(db, obj, data.dict())
 
 @router.delete('/{obj_id}')
+@role_required(UserRole.super_admin)
 def delete_call(obj_id: uuid.UUID, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)
     if not obj:


### PR DESCRIPTION
## Summary
- import permission utilities in call routes
- restrict `update_call` and `delete_call` to super admins

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68508f2d7244832cacd32990c5545396