### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+__pycache__/
+venv/
+.git/
+*.pyc
+*.pyo
+*.pyd
+.Python
+.env
+*.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY backend/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY backend/ .
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ uvicorn app.main:app --reload
 ```
 The API will be available at `http://localhost:8000`.
 
+## Running with Docker
+
+To build and start the API in a container run:
+```bash
+docker build -t projectcall .
+docker run --env-file backend/.env -p 8000:8000 projectcall
+```
+
 ## Soft delete and unique constraints
 
 Models using the `SoftDeleteMixin` keep records by setting an `is_deleted` flag


### PR DESCRIPTION
## Summary
- add Dockerfile to run the FastAPI backend
- ignore development artifacts with `.dockerignore`
- document running the project in Docker in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685090e69d5c832c8869dfc453b5e745