### PR TITLE
Add docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+__pycache__/
+venv/
+.git/
+*.pyc
+*.pyo
+*.pyd
+.Python
+.env
+*.swp

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ uvicorn app.main:app --reload
 ```
 The API will be available at `http://localhost:8000`.
 
+## Running with Docker
+
+To build and start the API in a container run:
+```bash
+docker build -t projectcall .
+docker run --env-file backend/.env -p 8000:8000 projectcall
+```
+
 ## Soft delete and unique constraints
 
 Models using the `SoftDeleteMixin` keep records by setting an `is_deleted` flag

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 WORKDIR /app
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY backend/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY backend/ .
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: "3.9"
+
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
+    volumes:
+      - ./backend:/app
+      - ./backend/.env.example:/app/.env
+    ports:
+      - "8000:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: project_call
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 10s
+      retries: 5
+      start_period: 5s
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary
- move Dockerfile into `backend`
- add a docker-compose file to run the FastAPI backend with PostgreSQL

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685090e69d5c832c8869dfc453b5e745