### PR TITLE
Update pydantic settings usage

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,4 +1,4 @@
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     DATABASE_URL: str

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ pydantic
 python-dotenv
 python-jose
 passlib[bcrypt]
+pydantic-settings


### PR DESCRIPTION
## Summary
- use BaseSettings from `pydantic_settings`
- add `pydantic-settings` dependency

## Testing
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `python -m uvicorn backend.app.main:app --port 8000 --host 127.0.0.1` *(fails: No module named uvicorn)*

------
https://chatgpt.com/codex/tasks/task_e_6850969b9d5c832c8d01cc7e155ba352