### PR TITLE
Update DATABASE_URL example for compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ This repository contains a simple FastAPI application for managing academic proj
    Copy `.env.example` inside the `backend` directory to `.env` and adjust the values.
 
    Required variables are:
-   - `DATABASE_URL` – PostgreSQL connection string
+   - `DATABASE_URL` – PostgreSQL connection string. When using
+     `docker-compose` this should be
+     `postgresql://postgres:postgres@db:5432/project_call`.
    - `SECRET_KEY` – application secret
 
 ## Running the app

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,4 @@
-DATABASE_URL=postgresql://postgres:postgres@db:5432/project_call
+DATABASE_URL=postgresql://postgres:postgres@db:5432/odtu_platform
 SECRET_KEY=change_me
 ACCESS_TOKEN_EXPIRE_MINUTES=60
 # Comma-separated list of MIME types allowed for uploaded attachments

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,4 @@
-DATABASE_URL=postgresql://user:password@localhost:5432/dbname
+DATABASE_URL=postgresql://postgres:postgres@db:5432/project_call
 SECRET_KEY=change_me
 ACCESS_TOKEN_EXPIRE_MINUTES=60
 # Comma-separated list of MIME types allowed for uploaded attachments


### PR DESCRIPTION
## Summary
- point DATABASE_URL in backend `.env.example` to Docker compose service
- document the compose connection string in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685096ab2688832cb17919e07599ff00