### PR TITLE
Add psycopg2-binary to backend requirements

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ python-dotenv
 python-jose
 passlib[bcrypt]
 pydantic-settings
+psycopg2-binary


### PR DESCRIPTION
## Summary
- include `psycopg2-binary` in `backend/requirements.txt`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68509c647bb0832c87c567e9f6a4eb4d