### PR TITLE
Add call application layout

### DIFF
--- a/frontend/src/routes/calls/apply/ApplicationLayout.tsx
+++ b/frontend/src/routes/calls/apply/ApplicationLayout.tsx
@@ -1,0 +1,54 @@
+import { useEffect } from "react";
+import { NavLink, Outlet, useParams, useLocation } from "react-router-dom";
+
+interface Step {
+  name: string;
+  path: string;
+}
+
+const steps: Step[] = [
+  { name: "Call Info", path: "step1" },
+  { name: "Upload", path: "step2" },
+  { name: "Review", path: "step3" },
+  { name: "Submit", path: "step4" },
+];
+
+export default function ApplicationLayout() {
+  const { callId } = useParams<{ callId: string }>();
+  const location = useLocation();
+
+  useEffect(() => {
+    if (callId) {
+      // Placeholder for fetching call information
+      // fetchCall(callId)
+    }
+  }, [callId]);
+
+  const currentStepIndex = steps.findIndex((step) =>
+    location.pathname.includes(step.path)
+  );
+
+  return (
+    <div className="p-4">
+      <nav className="mb-4 flex space-x-4" aria-label="Progress">
+        {steps.map((step, index) => (
+          <NavLink
+            key={step.path}
+            to={step.path}
+            className={({ isActive }) =>
+              [
+                "px-4 py-2 rounded-md",
+                index === currentStepIndex
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-muted text-muted-foreground",
+              ].join(" ")
+            }
+          >
+            {step.name}
+          </NavLink>
+        ))}
+      </nav>
+      <Outlet />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- scaffold frontend route layout `ApplicationLayout`
- include step navigation for nested application steps

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685190b63f9c832c9c5e43c398e55c2d