### PR TITLE
Create skeleton React frontend

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,13 @@
+import { BrowserRouter } from "react-router-dom";
+import { ToastProvider } from "./context/ToastProvider";
+import AppRoutes from "./routes";
+
+export default function App() {
+  return (
+    <ToastProvider>
+      <BrowserRouter>
+        <AppRoutes />
+      </BrowserRouter>
+    </ToastProvider>
+  );
+}

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -1,0 +1,12 @@
+import { Link } from "react-router-dom";
+
+export default function Navbar() {
+  return (
+    <nav className="bg-gray-200 p-4">
+      <div className="container mx-auto flex space-x-4">
+        <Link to="/">Calls</Link>
+        <Link to="/about">About</Link>
+      </div>
+    </nav>
+  );
+}

--- a/frontend/src/components/layout/PageContainer.tsx
+++ b/frontend/src/components/layout/PageContainer.tsx
@@ -1,0 +1,17 @@
+import { Outlet } from "react-router-dom";
+import Navbar from "./Navbar";
+import Sidebar from "./Sidebar";
+
+export default function PageContainer() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <div className="flex flex-1">
+        <Sidebar />
+        <main className="flex-1 p-4">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,0 +1,10 @@
+import { Link } from "react-router-dom";
+
+export default function Sidebar() {
+  return (
+    <aside className="w-48 bg-gray-100 p-4 space-y-2">
+      <Link to="/dashboard">Dashboard</Link>
+      <Link to="/calls/manage">Calls</Link>
+    </aside>
+  );
+}

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,9 @@
+import { ButtonHTMLAttributes } from "react";
+
+export default function Button({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button className="px-3 py-1 bg-blue-500 text-white rounded" {...props}>
+      {children}
+    </button>
+  );
+}

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -1,0 +1,5 @@
+import { ReactNode } from "react";
+
+export default function Card({ children }: { children: ReactNode }) {
+  return <div className="border rounded p-4 bg-white">{children}</div>;
+}

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -1,0 +1,5 @@
+import { InputHTMLAttributes } from "react";
+
+export default function Input(props: InputHTMLAttributes<HTMLInputElement>) {
+  return <input className="border p-2 rounded" {...props} />;
+}

--- a/frontend/src/components/ui/Table.tsx
+++ b/frontend/src/components/ui/Table.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from "react";
+
+export default function Table({ children }: { children: ReactNode }) {
+  return (
+    <table className="min-w-full border" cellPadding={8} cellSpacing={0}>
+      {children}
+    </table>
+  );
+}

--- a/frontend/src/context/ToastProvider.tsx
+++ b/frontend/src/context/ToastProvider.tsx
@@ -1,0 +1,31 @@
+import { createContext, ReactNode, useContext, useState } from "react";
+
+interface ToastContextValue {
+  show: (message: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue>({ show: () => {} });
+
+export function useToast() {
+  return useContext(ToastContext);
+}
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [message, setMessage] = useState<string | null>(null);
+
+  const show = (msg: string) => {
+    setMessage(msg);
+    setTimeout(() => setMessage(null), 3000);
+  };
+
+  return (
+    <ToastContext.Provider value={{ show }}>
+      {children}
+      {message && (
+        <div className="fixed bottom-4 right-4 bg-gray-800 text-white p-2 rounded">
+          {message}
+        </div>
+      )}
+    </ToastContext.Provider>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,10 @@
+export async function apiFetch(path: string, options: RequestInit = {}) {
+  const token = localStorage.getItem("token");
+  const headers = new Headers(options.headers);
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+  const res = await fetch(path, { ...options, headers });
+  if (!res.ok) throw new Error(res.statusText);
+  return res.json();
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+
+const rootElement = document.getElementById("root");
+if (rootElement) {
+  createRoot(rootElement).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+}

--- a/frontend/src/routes/AboutPage.tsx
+++ b/frontend/src/routes/AboutPage.tsx
@@ -1,0 +1,3 @@
+export default function AboutPage() {
+  return <div>About this platform.</div>;
+}

--- a/frontend/src/routes/CallApplicationsPage.tsx
+++ b/frontend/src/routes/CallApplicationsPage.tsx
@@ -1,0 +1,3 @@
+export default function CallApplicationsPage() {
+  return <div>List applications and assign reviewers.</div>;
+}

--- a/frontend/src/routes/CallManagementPage.tsx
+++ b/frontend/src/routes/CallManagementPage.tsx
@@ -1,0 +1,3 @@
+export default function CallManagementPage() {
+  return <div>Manage calls.</div>;
+}

--- a/frontend/src/routes/CallPreviewPage.tsx
+++ b/frontend/src/routes/CallPreviewPage.tsx
@@ -1,0 +1,3 @@
+export default function CallPreviewPage() {
+  return <div>Preview documents in order.</div>;
+}

--- a/frontend/src/routes/CallsPage.tsx
+++ b/frontend/src/routes/CallsPage.tsx
@@ -1,0 +1,3 @@
+export default function CallsPage() {
+  return <div>List of open calls.</div>;
+}

--- a/frontend/src/routes/DashboardPage.tsx
+++ b/frontend/src/routes/DashboardPage.tsx
@@ -1,0 +1,3 @@
+export default function DashboardPage() {
+  return <div>Admin dashboard.</div>;
+}

--- a/frontend/src/routes/LoginPage.tsx
+++ b/frontend/src/routes/LoginPage.tsx
@@ -1,0 +1,17 @@
+import Button from "../components/ui/Button";
+import Input from "../components/ui/Input";
+import { useToast } from "../context/ToastProvider";
+
+export default function LoginPage() {
+  const { show } = useToast();
+  const handleLogin = () => show("Logged in");
+
+  return (
+    <div className="space-y-2 p-4">
+      <h1>Login</h1>
+      <Input placeholder="Email" />
+      <Input type="password" placeholder="Password" />
+      <Button onClick={handleLogin}>Login</Button>
+    </div>
+  );
+}

--- a/frontend/src/routes/RegisterPage.tsx
+++ b/frontend/src/routes/RegisterPage.tsx
@@ -1,0 +1,17 @@
+import Button from "../components/ui/Button";
+import Input from "../components/ui/Input";
+import { useToast } from "../context/ToastProvider";
+
+export default function RegisterPage() {
+  const { show } = useToast();
+  const handleRegister = () => show("Registered");
+
+  return (
+    <div className="space-y-2 p-4">
+      <h1>Register</h1>
+      <Input placeholder="Email" />
+      <Input type="password" placeholder="Password" />
+      <Button onClick={handleRegister}>Register</Button>
+    </div>
+  );
+}

--- a/frontend/src/routes/ReviewPage.tsx
+++ b/frontend/src/routes/ReviewPage.tsx
@@ -1,0 +1,6 @@
+import { useParams } from "react-router-dom";
+
+export default function ReviewPage() {
+  const { reviewId } = useParams<{ reviewId: string }>();
+  return <div>Review form for {reviewId}</div>;
+}

--- a/frontend/src/routes/calls/apply/Step1_CallInfo.tsx
+++ b/frontend/src/routes/calls/apply/Step1_CallInfo.tsx
@@ -1,0 +1,3 @@
+export default function Step1_CallInfo() {
+  return <div>Call information goes here.</div>;
+}

--- a/frontend/src/routes/calls/apply/Step2_Upload.tsx
+++ b/frontend/src/routes/calls/apply/Step2_Upload.tsx
@@ -1,0 +1,3 @@
+export default function Step2_Upload() {
+  return <div>Upload your documents.</div>;
+}

--- a/frontend/src/routes/calls/apply/Step3_Review.tsx
+++ b/frontend/src/routes/calls/apply/Step3_Review.tsx
@@ -1,0 +1,3 @@
+export default function Step3_Review() {
+  return <div>Review uploaded files.</div>;
+}

--- a/frontend/src/routes/calls/apply/Step4_Submit.tsx
+++ b/frontend/src/routes/calls/apply/Step4_Submit.tsx
@@ -1,0 +1,13 @@
+import Button from "../../../components/ui/Button";
+import { useToast } from "../../../context/ToastProvider";
+
+export default function Step4_Submit() {
+  const { show } = useToast();
+  const handleSubmit = () => show("Application submitted");
+  return (
+    <div>
+      <p>Ready to submit your application.</p>
+      <Button onClick={handleSubmit}>Submit</Button>
+    </div>
+  );
+}

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,0 +1,41 @@
+import { Routes, Route, Navigate } from "react-router-dom";
+import PageContainer from "../components/layout/PageContainer";
+import ApplicationLayout from "./calls/apply/ApplicationLayout";
+import Step1_CallInfo from "./calls/apply/Step1_CallInfo";
+import Step2_Upload from "./calls/apply/Step2_Upload";
+import Step3_Review from "./calls/apply/Step3_Review";
+import Step4_Submit from "./calls/apply/Step4_Submit";
+import LoginPage from "./LoginPage";
+import RegisterPage from "./RegisterPage";
+import CallsPage from "./CallsPage";
+import AboutPage from "./AboutPage";
+import DashboardPage from "./DashboardPage";
+import CallManagementPage from "./CallManagementPage";
+import CallApplicationsPage from "./CallApplicationsPage";
+import CallPreviewPage from "./CallPreviewPage";
+import ReviewPage from "./ReviewPage";
+
+export default function AppRoutes() {
+  return (
+    <Routes>
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/register" element={<RegisterPage />} />
+      <Route path="/review/:reviewId" element={<ReviewPage />} />
+      <Route path="/" element={<PageContainer />}> 
+        <Route index element={<CallsPage />} />
+        <Route path="about" element={<AboutPage />} />
+        <Route path="dashboard" element={<DashboardPage />} />
+        <Route path="calls/manage" element={<CallManagementPage />} />
+        <Route path="calls/:callId/applications" element={<CallApplicationsPage />} />
+        <Route path="calls/:callId/preview" element={<CallPreviewPage />} />
+        <Route path="calls/:callId/apply" element={<ApplicationLayout />}>
+          <Route index element={<Navigate to="step1" replace />} />
+          <Route path="step1" element={<Step1_CallInfo />} />
+          <Route path="step2" element={<Step2_Upload />} />
+          <Route path="step3" element={<Step3_Review />} />
+          <Route path="step4" element={<Step4_Submit />} />
+        </Route>
+      </Route>
+    </Routes>
+  );
+}


### PR DESCRIPTION
## Summary
- wire up basic router in `App.tsx` and `routes/index.tsx`
- add layout components `Navbar`, `Sidebar`, `PageContainer`
- provide reusable UI components (`Button`, `Input`, etc.)
- implement toast context and simple API helper
- scaffold pages for applicant flow, admin panel, reviewer and auth

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685193d72118832c8cd6ec0e2300d8af