### PR TITLE
Add call listing with API fetch

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -8,3 +8,7 @@ export async function apiFetch(path: string, options: RequestInit = {}) {
   if (!res.ok) throw new Error(res.statusText);
   return res.json();
 }
+
+export async function getCalls() {
+  return apiFetch("/calls");
+}

--- a/frontend/src/routes/CallsPage.tsx
+++ b/frontend/src/routes/CallsPage.tsx
@@ -1,3 +1,51 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import Table from "../components/ui/Table";
+import { getCalls } from "../lib/api";
+
+interface Call {
+  id: string;
+  title: string;
+  status: string;
+}
+
 export default function CallsPage() {
-  return <div>List of open calls.</div>;
+  const [calls, setCalls] = useState<Call[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getCalls()
+      .then(setCalls)
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div className="text-red-500">Error: {error}</div>;
+
+  return (
+    <Table>
+      <thead>
+        <tr>
+          <th align="left">Title</th>
+          <th align="left">Status</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {calls.map((call) => (
+          <tr key={call.id} className="odd:bg-gray-50">
+            <td>{call.title}</td>
+            <td>{call.status}</td>
+            <td>
+              <Link to={`/calls/${call.id}/apply`} className="text-blue-600">
+                Apply
+              </Link>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  );
 }


### PR DESCRIPTION
## Summary
- provide `getCalls` API helper
- load calls on the Calls page with loading and error states
- list results in a table with Apply links

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851a0bec7c4832cb4cd98dd1f2d219d