### PR TITLE
Add admin page implementations

### DIFF
--- a/frontend/src/components/documents/DocumentList.tsx
+++ b/frontend/src/components/documents/DocumentList.tsx
@@ -1,0 +1,28 @@
+import { useState } from "react";
+
+export interface Document {
+  id: string;
+  name: string;
+  url: string;
+}
+
+export default function DocumentList({ documents }: { documents: Document[] }) {
+  const [index, setIndex] = useState(0);
+  const current = documents[index];
+
+  const prev = () => setIndex((i) => Math.max(i - 1, 0));
+  const next = () => setIndex((i) => Math.min(i + 1, documents.length - 1));
+
+  if (!current) return <div>No documents.</div>;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex space-x-2">
+        <button onClick={prev} disabled={index === 0} className="px-2 py-1 bg-gray-200 rounded" >Prev</button>
+        <button onClick={next} disabled={index === documents.length - 1} className="px-2 py-1 bg-gray-200 rounded" >Next</button>
+      </div>
+      <iframe title={current.name} src={current.url} className="w-full h-96 border" />
+      <div className="text-sm text-center">{index + 1} / {documents.length}</div>
+    </div>
+  );
+}

--- a/frontend/src/routes/CallApplicationsPage.tsx
+++ b/frontend/src/routes/CallApplicationsPage.tsx
@@ -1,3 +1,79 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import Button from "../components/ui/Button";
+import Input from "../components/ui/Input";
+import Table from "../components/ui/Table";
+import { apiFetch } from "../lib/api";
+import { useToast } from "../context/ToastProvider";
+
+interface Application {
+  id: string;
+  call_id: string;
+}
+
 export default function CallApplicationsPage() {
-  return <div>List applications and assign reviewers.</div>;
+  const { callId } = useParams<{ callId: string }>();
+  const [applications, setApplications] = useState<Application[]>([]);
+  const [reviewers, setReviewers] = useState<Record<string, string>>({});
+  const { show } = useToast();
+
+  async function load() {
+    const data = await apiFetch("/applications");
+    setApplications(data.filter((a: Application) => a.call_id === callId));
+  }
+
+  useEffect(() => {
+    load();
+  }, [callId]);
+
+  async function assign(appId: string) {
+    const reviewerId = reviewers[appId];
+    if (!reviewerId) return;
+    await apiFetch("/review_reports", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        call_id: callId,
+        application_id: appId,
+        reviewer_id: reviewerId,
+      }),
+    });
+    show("Reviewer assigned");
+    setReviewers((r) => ({ ...r, [appId]: "" }));
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-bold">Applications</h1>
+      <Table>
+        <thead>
+          <tr className="bg-gray-100">
+            <th>ID</th>
+            <th>Reviewer</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {applications.map((app) => (
+            <tr key={app.id}>
+              <td>{app.id}</td>
+              <td>
+                <Input
+                  value={reviewers[app.id] || ""}
+                  onChange={(e) =>
+                    setReviewers({ ...reviewers, [app.id]: e.target.value })
+                  }
+                />
+              </td>
+              <td>
+                <Button type="button" onClick={() => assign(app.id)}>
+                  Assign
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </div>
+  );
 }

--- a/frontend/src/routes/CallManagementPage.tsx
+++ b/frontend/src/routes/CallManagementPage.tsx
@@ -1,3 +1,98 @@
+import { FormEvent, useEffect, useState } from "react";
+import Button from "../components/ui/Button";
+import Input from "../components/ui/Input";
+import Table from "../components/ui/Table";
+import { apiFetch } from "../lib/api";
+
+interface Call {
+  id: string;
+  title: string;
+  description?: string;
+}
+
 export default function CallManagementPage() {
-  return <div>Manage calls.</div>;
+  const [calls, setCalls] = useState<Call[]>([]);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [editing, setEditing] = useState<Call | null>(null);
+
+  async function load() {
+    const data = await apiFetch("/calls");
+    setCalls(data);
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const reset = () => {
+    setTitle("");
+    setDescription("");
+    setEditing(null);
+  };
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    const body = JSON.stringify({ title, description });
+    const headers = { "Content-Type": "application/json" };
+    if (editing) {
+      await apiFetch(`/calls/${editing.id}`, { method: "PUT", headers, body });
+    } else {
+      await apiFetch("/calls", { method: "POST", headers, body });
+    }
+    reset();
+    load();
+  }
+
+  async function remove(id: string) {
+    await apiFetch(`/calls/${id}`, { method: "DELETE" });
+    load();
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-bold">Manage Calls</h1>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <Input
+          placeholder="Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <Input
+          placeholder="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+        <Button type="submit">{editing ? "Update" : "Create"}</Button>
+        {editing && (
+          <Button type="button" onClick={reset}>
+            Cancel
+          </Button>
+        )}
+      </form>
+      <Table>
+        <thead>
+          <tr className="bg-gray-100">
+            <th>Title</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {calls.map((c) => (
+            <tr key={c.id}>
+              <td>{c.title}</td>
+              <td className="space-x-2">
+                <Button type="button" onClick={() => {setEditing(c);setTitle(c.title);setDescription(c.description || "");}}>
+                  Edit
+                </Button>
+                <Button type="button" onClick={() => remove(c.id)}>
+                  Delete
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </div>
+  );
 }

--- a/frontend/src/routes/CallPreviewPage.tsx
+++ b/frontend/src/routes/CallPreviewPage.tsx
@@ -1,3 +1,29 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import DocumentList, { Document } from "../components/documents/DocumentList";
+import { apiFetch } from "../lib/api";
+
 export default function CallPreviewPage() {
-  return <div>Preview documents in order.</div>;
+  const { callId } = useParams<{ callId: string }>();
+  const [documents, setDocuments] = useState<Document[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      const apps = await apiFetch("/applications");
+      const appIds = apps.filter((a: any) => a.call_id === callId).map((a: any) => a.id);
+      const attachments = await apiFetch("/attachments");
+      const docs = attachments
+        .filter((a: any) => appIds.includes(a.application_id))
+        .map((a: any) => ({ id: a.id, name: a.doc_name || "document", url: `/files/${a.id}` }));
+      setDocuments(docs);
+    }
+    load();
+  }, [callId]);
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-bold">Call Documents</h1>
+      <DocumentList documents={documents} />
+    </div>
+  );
 }

--- a/frontend/src/routes/DashboardPage.tsx
+++ b/frontend/src/routes/DashboardPage.tsx
@@ -1,3 +1,30 @@
+import { useEffect, useState } from "react";
+import Card from "../components/ui/Card";
+import { apiFetch } from "../lib/api";
+
 export default function DashboardPage() {
-  return <div>Admin dashboard.</div>;
+  const [stats, setStats] = useState({ calls: 0, applications: 0 });
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const calls = await apiFetch("/calls");
+        const apps = await apiFetch("/applications");
+        setStats({ calls: calls.length, applications: apps.length });
+      } catch {
+        // ignore errors for demo
+      }
+    }
+    load();
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-bold">Dashboard</h1>
+      <Card>
+        <p>Total Calls: {stats.calls}</p>
+        <p>Total Applications: {stats.applications}</p>
+      </Card>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- fetch statistics on dashboard
- manage calls with create/edit/delete
- assign reviewers to applications
- preview call documents with navigation
- add DocumentList component

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6851a0c5451c832cbc8b10580e1cb49c