### PR TITLE
Implement review page with attachments

### DIFF
--- a/backend/app/routes/attachment.py
+++ b/backend/app/routes/attachment.py
@@ -8,6 +8,14 @@ from ..schemas import AttachmentCreate, AttachmentRead
 
 router = APIRouter(prefix="/attachments", tags=["Attachment"])
 
+
+@router.get('/application/{application_id}', response_model=list[AttachmentRead])
+def read_attachments_by_application(
+    application_id: uuid.UUID, db: Session = Depends(get_db)
+):
+    """Return attachments belonging to a specific application."""
+    return list(crud.get_attachments_by_application_id(db, application_id))
+
 @router.post('/', response_model=AttachmentRead)
 def create_attachment(data: AttachmentCreate, db: Session = Depends(get_db)):
     return crud.create(db, data.dict())

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -8,3 +8,19 @@ export async function apiFetch(path: string, options: RequestInit = {}) {
   if (!res.ok) throw new Error(res.statusText);
   return res.json();
 }
+
+export function getReviewReport(id: string) {
+  return apiFetch(`/review_reports/${id}`);
+}
+
+export function getApplicationAttachments(applicationId: string) {
+  return apiFetch(`/attachments/application/${applicationId}`);
+}
+
+export function createReviewReport(data: Record<string, unknown>) {
+  return apiFetch(`/review_reports`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}

--- a/frontend/src/routes/ReviewPage.tsx
+++ b/frontend/src/routes/ReviewPage.tsx
@@ -1,6 +1,116 @@
+import { useEffect, useState, ChangeEvent } from "react";
 import { useParams } from "react-router-dom";
+import Input from "../components/ui/Input";
+import Button from "../components/ui/Button";
+import { useToast } from "../context/ToastProvider";
+import {
+  getReviewReport,
+  getApplicationAttachments,
+  createReviewReport,
+} from "../lib/api";
 
 export default function ReviewPage() {
   const { reviewId } = useParams<{ reviewId: string }>();
-  return <div>Review form for {reviewId}</div>;
+  const { show } = useToast();
+  const [review, setReview] = useState<any | null>(null);
+  const [attachments, setAttachments] = useState<any[]>([]);
+  const [form, setForm] = useState({
+    excellence_grade: "",
+    impact_grade: "",
+    implementation_grade: "",
+    additional_comments: "",
+  });
+
+  useEffect(() => {
+    if (!reviewId) return;
+    getReviewReport(reviewId)
+      .then(setReview)
+      .catch((err) => show(err.message));
+  }, [reviewId, show]);
+
+  useEffect(() => {
+    if (review?.application_id) {
+      getApplicationAttachments(review.application_id)
+        .then(setAttachments)
+        .catch((err) => show(err.message));
+    }
+  }, [review, show]);
+
+  const handleChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = () => {
+    if (!review) return;
+    const data = { ...review, ...form };
+    createReviewReport(data)
+      .then(() => show("Review submitted"))
+      .catch((err) => show(err.message));
+  };
+
+  if (!review) return <div>Loading...</div>;
+
+  return (
+    <div className="space-y-4 p-4">
+      <h1>Review {review.id}</h1>
+      <div>
+        <h2>Attachments</h2>
+        <ul className="list-disc pl-4">
+          {attachments.map((a) => (
+            <li key={a.id}>
+              <a
+                href={`/files/${a.id}`}
+                className="text-blue-600 underline"
+                target="_blank"
+                rel="noreferrer"
+              >
+                {a.doc_name}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="space-y-2">
+        <div>
+          <label>Excellence Grade</label>
+          <Input
+            name="excellence_grade"
+            type="number"
+            value={form.excellence_grade}
+            onChange={handleChange}
+          />
+        </div>
+        <div>
+          <label>Impact Grade</label>
+          <Input
+            name="impact_grade"
+            type="number"
+            value={form.impact_grade}
+            onChange={handleChange}
+          />
+        </div>
+        <div>
+          <label>Implementation Grade</label>
+          <Input
+            name="implementation_grade"
+            type="number"
+            value={form.implementation_grade}
+            onChange={handleChange}
+          />
+        </div>
+        <div>
+          <label>Comments</label>
+          <textarea
+            name="additional_comments"
+            className="border p-2 rounded w-full"
+            value={form.additional_comments}
+            onChange={handleChange}
+          />
+        </div>
+        <Button onClick={handleSubmit}>Submit Review</Button>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- allow listing attachments for an application via new endpoint
- expose API helpers for review reports and attachments in the frontend
- implement review page to fetch review data, show attachments and submit scores

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6851a0c75fc4832c84ec0ec0930f2d5a