### PR TITLE
Add toast messages and loading states

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,10 +1,16 @@
+const API_BASE = "http://localhost:8000";
+
 export async function apiFetch(path: string, options: RequestInit = {}) {
   const token = localStorage.getItem("token");
   const headers = new Headers(options.headers);
   if (token) {
     headers.set("Authorization", `Bearer ${token}`);
   }
-  const res = await fetch(path, { ...options, headers });
-  if (!res.ok) throw new Error(res.statusText);
+  const res = await fetch(`${API_BASE}${path}`, { ...options, headers });
+  if (!res.ok) {
+    const message = await res.text();
+    throw new Error(message || res.statusText);
+  }
+  if (res.status === 204) return null;
   return res.json();
 }

--- a/frontend/src/routes/CallApplicationsPage.tsx
+++ b/frontend/src/routes/CallApplicationsPage.tsx
@@ -1,3 +1,43 @@
+import { useEffect, useState } from "react";
+import { useToast } from "../context/ToastProvider";
+import { apiFetch } from "../lib/api";
+
+interface Application {
+  id: string;
+}
+
 export default function CallApplicationsPage() {
-  return <div>List applications and assign reviewers.</div>;
+  const { show } = useToast();
+  const [apps, setApps] = useState<Application[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    apiFetch("/applications")
+      .then((data) => {
+        setApps(data);
+        show("Applications loaded");
+      })
+      .catch((err) => {
+        setError(err.message);
+        show("Failed to load applications");
+      })
+      .finally(() => setLoading(false));
+  }, [show]);
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div className="text-red-500">Error: {error}</div>;
+
+  return (
+    <div>
+      <h1>Applications</h1>
+      <ul className="list-disc pl-5">
+        {apps.map((a) => (
+          <li key={a.id}>{a.id}</li>
+        ))}
+      </ul>
+    </div>
+  );
 }

--- a/frontend/src/routes/CallPreviewPage.tsx
+++ b/frontend/src/routes/CallPreviewPage.tsx
@@ -1,3 +1,38 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { useToast } from "../context/ToastProvider";
+import { apiFetch } from "../lib/api";
+
+interface Call {
+  id: string;
+  title: string;
+}
+
 export default function CallPreviewPage() {
-  return <div>Preview documents in order.</div>;
+  const { callId } = useParams<{ callId: string }>();
+  const { show } = useToast();
+  const [call, setCall] = useState<Call | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!callId) return;
+    setLoading(true);
+    setError(null);
+    apiFetch(`/calls/${callId}`)
+      .then((data) => {
+        setCall(data);
+        show("Call loaded");
+      })
+      .catch((err) => {
+        setError(err.message);
+        show("Failed to load call");
+      })
+      .finally(() => setLoading(false));
+  }, [callId, show]);
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div className="text-red-500">Error: {error}</div>;
+
+  return <div>{call ? call.title : "No call"}</div>;
 }

--- a/frontend/src/routes/CallsPage.tsx
+++ b/frontend/src/routes/CallsPage.tsx
@@ -1,3 +1,44 @@
+import { useEffect, useState } from "react";
+import { useToast } from "../context/ToastProvider";
+import { apiFetch } from "../lib/api";
+
+interface Call {
+  id: string;
+  title: string;
+}
+
 export default function CallsPage() {
-  return <div>List of open calls.</div>;
+  const { show } = useToast();
+  const [calls, setCalls] = useState<Call[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    apiFetch("/calls")
+      .then((data) => {
+        setCalls(data);
+        show("Calls loaded");
+      })
+      .catch((err) => {
+        setError(err.message);
+        show("Failed to load calls");
+      })
+      .finally(() => setLoading(false));
+  }, [show]);
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div className="text-red-500">Error: {error}</div>;
+
+  return (
+    <div>
+      <h1>Open Calls</h1>
+      <ul className="list-disc pl-5">
+        {calls.map((c) => (
+          <li key={c.id}>{c.title}</li>
+        ))}
+      </ul>
+    </div>
+  );
 }

--- a/frontend/src/routes/LoginPage.tsx
+++ b/frontend/src/routes/LoginPage.tsx
@@ -1,17 +1,44 @@
+import { useState } from "react";
 import Button from "../components/ui/Button";
 import Input from "../components/ui/Input";
 import { useToast } from "../context/ToastProvider";
+import { apiFetch } from "../lib/api";
 
 export default function LoginPage() {
   const { show } = useToast();
-  const handleLogin = () => show("Logged in");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleLogin = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await apiFetch("/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
+      localStorage.setItem("token", data.access_token);
+      show("Logged in successfully");
+    } catch (err) {
+      setError((err as Error).message);
+      show("Login failed");
+    } finally {
+      setLoading(false);
+    }
+  };
 
   return (
     <div className="space-y-2 p-4">
       <h1>Login</h1>
-      <Input placeholder="Email" />
-      <Input type="password" placeholder="Password" />
-      <Button onClick={handleLogin}>Login</Button>
+      <Input placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
+      <Input type="password" placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} />
+      <Button onClick={handleLogin} disabled={loading}>
+        {loading ? "Loading..." : "Login"}
+      </Button>
+      {error && <div className="text-red-500">Error: {error}</div>}
     </div>
   );
 }

--- a/frontend/src/routes/RegisterPage.tsx
+++ b/frontend/src/routes/RegisterPage.tsx
@@ -1,17 +1,43 @@
+import { useState } from "react";
 import Button from "../components/ui/Button";
 import Input from "../components/ui/Input";
 import { useToast } from "../context/ToastProvider";
+import { apiFetch } from "../lib/api";
 
 export default function RegisterPage() {
   const { show } = useToast();
-  const handleRegister = () => show("Registered");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleRegister = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await apiFetch("/auth/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
+      show("Registered successfully");
+    } catch (err) {
+      setError((err as Error).message);
+      show("Registration failed");
+    } finally {
+      setLoading(false);
+    }
+  };
 
   return (
     <div className="space-y-2 p-4">
       <h1>Register</h1>
-      <Input placeholder="Email" />
-      <Input type="password" placeholder="Password" />
-      <Button onClick={handleRegister}>Register</Button>
+      <Input placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
+      <Input type="password" placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} />
+      <Button onClick={handleRegister} disabled={loading}>
+        {loading ? "Loading..." : "Register"}
+      </Button>
+      {error && <div className="text-red-500">Error: {error}</div>}
     </div>
   );
 }

--- a/frontend/src/routes/calls/apply/Step4_Submit.tsx
+++ b/frontend/src/routes/calls/apply/Step4_Submit.tsx
@@ -1,13 +1,41 @@
+import { useState } from "react";
+import { useParams } from "react-router-dom";
 import Button from "../../../components/ui/Button";
 import { useToast } from "../../../context/ToastProvider";
+import { apiFetch } from "../../../lib/api";
 
 export default function Step4_Submit() {
+  const { callId } = useParams<{ callId: string }>();
   const { show } = useToast();
-  const handleSubmit = () => show("Application submitted");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    if (!callId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      await apiFetch("/applications", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ call_id: callId }),
+      });
+      show("Application submitted");
+    } catch (err) {
+      setError((err as Error).message);
+      show("Submission failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <div>
       <p>Ready to submit your application.</p>
-      <Button onClick={handleSubmit}>Submit</Button>
+      <Button onClick={handleSubmit} disabled={loading}>
+        {loading ? "Loading..." : "Submit"}
+      </Button>
+      {error && <div className="text-red-500">Error: {error}</div>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show a toast on success/failure for each async action
- add simple loading/error indicators to pages that fetch data
- centralize API base URL

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6851a0cc7e60832ca7e236b2be7cda4e