### PR TITLE
Add NotFound page

### DIFF
--- a/frontend/src/routes/NotFoundPage.tsx
+++ b/frontend/src/routes/NotFoundPage.tsx
@@ -1,0 +1,3 @@
+export default function NotFoundPage() {
+  return <div>Page not found.</div>;
+}

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -14,6 +14,7 @@ import CallManagementPage from "./CallManagementPage";
 import CallApplicationsPage from "./CallApplicationsPage";
 import CallPreviewPage from "./CallPreviewPage";
 import ReviewPage from "./ReviewPage";
+import NotFoundPage from "./NotFoundPage";
 
 export default function AppRoutes() {
   return (
@@ -21,7 +22,7 @@ export default function AppRoutes() {
       <Route path="/login" element={<LoginPage />} />
       <Route path="/register" element={<RegisterPage />} />
       <Route path="/review/:reviewId" element={<ReviewPage />} />
-      <Route path="/" element={<PageContainer />}> 
+      <Route path="/" element={<PageContainer />}>
         <Route index element={<CallsPage />} />
         <Route path="about" element={<AboutPage />} />
         <Route path="dashboard" element={<DashboardPage />} />
@@ -36,6 +37,7 @@ export default function AppRoutes() {
           <Route path="step4" element={<Step4_Submit />} />
         </Route>
       </Route>
+      <Route path="*" element={<NotFoundPage />} />
     </Routes>
   );
 }


### PR DESCRIPTION
## Summary
- handle unknown routes on the frontend
- render simple `NotFoundPage`

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6851a0d02d8c832c9de235a05a107604