### PR TITLE
Add auth context and integrate with login/register

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,13 +1,16 @@
 import { BrowserRouter } from "react-router-dom";
 import { ToastProvider } from "./context/ToastProvider";
+import { AuthProvider } from "./context/AuthProvider";
 import AppRoutes from "./routes";
 
 export default function App() {
   return (
-    <ToastProvider>
-      <BrowserRouter>
-        <AppRoutes />
-      </BrowserRouter>
-    </ToastProvider>
+    <AuthProvider>
+      <ToastProvider>
+        <BrowserRouter>
+          <AppRoutes />
+        </BrowserRouter>
+      </ToastProvider>
+    </AuthProvider>
   );
 }

--- a/frontend/src/context/AuthProvider.tsx
+++ b/frontend/src/context/AuthProvider.tsx
@@ -1,0 +1,81 @@
+import { createContext, ReactNode, useContext, useEffect, useState } from "react";
+import { apiFetch } from "../lib/api";
+
+interface AuthState {
+  token: string | null;
+  user: { id: string; role: string } | null;
+}
+
+interface AuthContextValue extends AuthState {
+  login: (email: string, password: string) => Promise<void>;
+  register: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  token: null,
+  user: null,
+  login: async () => {},
+  register: async () => {},
+  logout: () => {},
+});
+
+function decodeToken(token: string): { id: string; role: string } | null {
+  try {
+    const payload = JSON.parse(atob(token.split(".")[1]));
+    return { id: payload.sub, role: payload.role };
+  } catch {
+    return null;
+  }
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<AuthState>(() => {
+    const stored = localStorage.getItem("token");
+    if (stored) {
+      return { token: stored, user: decodeToken(stored) };
+    }
+    return { token: null, user: null };
+  });
+
+  useEffect(() => {
+    if (state.token) {
+      localStorage.setItem("token", state.token);
+    } else {
+      localStorage.removeItem("token");
+    }
+  }, [state.token]);
+
+  const login = async (email: string, password: string) => {
+    const data = await apiFetch("/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    });
+    setState({ token: data.access_token, user: decodeToken(data.access_token) });
+  };
+
+  const register = async (email: string, password: string) => {
+    await apiFetch("/auth/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password, first_name: "", last_name: "" }),
+    });
+    await login(email, password);
+  };
+
+  const logout = () => {
+    setState({ token: null, user: null });
+  };
+
+  return (
+    <AuthContext.Provider value={{ ...state, login, register, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}
+

--- a/frontend/src/routes/LoginPage.tsx
+++ b/frontend/src/routes/LoginPage.tsx
@@ -1,16 +1,32 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import Button from "../components/ui/Button";
 import Input from "../components/ui/Input";
 import { useToast } from "../context/ToastProvider";
+import { useAuth } from "../context/AuthProvider";
 
 export default function LoginPage() {
   const { show } = useToast();
-  const handleLogin = () => show("Logged in");
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleLogin = async () => {
+    try {
+      await login(email, password);
+      show("Logged in");
+      navigate("/");
+    } catch {
+      show("Login failed");
+    }
+  };
 
   return (
     <div className="space-y-2 p-4">
       <h1>Login</h1>
-      <Input placeholder="Email" />
-      <Input type="password" placeholder="Password" />
+      <Input placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
+      <Input type="password" placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} />
       <Button onClick={handleLogin}>Login</Button>
     </div>
   );

--- a/frontend/src/routes/RegisterPage.tsx
+++ b/frontend/src/routes/RegisterPage.tsx
@@ -1,16 +1,32 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import Button from "../components/ui/Button";
 import Input from "../components/ui/Input";
 import { useToast } from "../context/ToastProvider";
+import { useAuth } from "../context/AuthProvider";
 
 export default function RegisterPage() {
   const { show } = useToast();
-  const handleRegister = () => show("Registered");
+  const { register } = useAuth();
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleRegister = async () => {
+    try {
+      await register(email, password);
+      show("Registered");
+      navigate("/");
+    } catch {
+      show("Registration failed");
+    }
+  };
 
   return (
     <div className="space-y-2 p-4">
       <h1>Register</h1>
-      <Input placeholder="Email" />
-      <Input type="password" placeholder="Password" />
+      <Input placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
+      <Input type="password" placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} />
       <Button onClick={handleRegister}>Register</Button>
     </div>
   );


### PR DESCRIPTION
## Summary
- create `AuthProvider` with token persistence and login/register/logout helpers
- expose a `useAuth` hook for consuming the context
- wrap the app with `AuthProvider`
- update login and register pages to authenticate and redirect

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6851a0b44458832cb3229e156c1d6376