### PR TITLE
Remove unused login import

### DIFF
--- a/frontend/src/routes/LoginPage.tsx
+++ b/frontend/src/routes/LoginPage.tsx
@@ -3,7 +3,6 @@ import Button from "../components/ui/Button";
 import Input from "../components/ui/Input";
 import { useToast } from "../context/ToastProvider";
 import { apiFetch } from "../lib/api";
-import { login } from "../lib/api/auth";
 
 
 export default function LoginPage() {


### PR DESCRIPTION
## Summary
- clean up unused `login` import in `LoginPage`

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6851ccf33920832c94af1bacc0000ef2