### PR TITLE
Remove duplicate imports in call route

### DIFF
--- a/backend/app/routes/call.py
+++ b/backend/app/routes/call.py
@@ -8,8 +8,6 @@ from ..core.enums import UserRole
 from ..database import get_db
 from ..crud import call as crud
 from ..schemas import CallCreate, CallRead
-from ..core.security import role_required
-from ..core.enums import UserRole
 
 router = APIRouter(prefix="/calls", tags=["Call"])
 


### PR DESCRIPTION
## Summary
- tidy repeated imports in `call.py`

## Testing
- `python -m py_compile backend/app/routes/call.py`
- `python -m py_compile backend/app/routes/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6851cd04b280832c8a755eb9fa7f2589