### PR TITLE
Unify call API usage

### DIFF
--- a/frontend/src/context/ApplicationProvider.tsx
+++ b/frontend/src/context/ApplicationProvider.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useEffect, useState, ReactNode } from "react";
 import { apiFetch } from "../lib/api";
+import { getCall } from "../lib/api/calls";
 
 interface Call {
   id: string;
@@ -49,7 +50,7 @@ export function ApplicationProvider({
 
   useEffect(() => {
     if (callId) {
-      apiFetch(`/calls/${callId}`)
+      getCall(callId)
         .then(setCall)
         .catch(() => {});
     }

--- a/frontend/src/routes/CallManagementPage.tsx
+++ b/frontend/src/routes/CallManagementPage.tsx
@@ -3,6 +3,7 @@ import Button from "../components/ui/Button";
 import Input from "../components/ui/Input";
 import Table from "../components/ui/Table";
 import { apiFetch } from "../lib/api";
+import { getCalls } from "../lib/api/calls";
 
 interface Call {
   id: string;
@@ -17,7 +18,7 @@ export default function CallManagementPage() {
   const [editing, setEditing] = useState<Call | null>(null);
 
   async function load() {
-    const data = await apiFetch("/calls");
+    const data = await getCalls();
     setCalls(data);
   }
 

--- a/frontend/src/routes/CallPreviewPage.tsx
+++ b/frontend/src/routes/CallPreviewPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useToast } from "../context/ToastProvider";
-import { apiFetch } from "../lib/api";
+import { getCall } from "../lib/api/calls";
 
 interface Call {
   id: string;
@@ -19,7 +19,7 @@ export default function CallPreviewPage() {
     if (!callId) return;
     setLoading(true);
     setError(null);
-    apiFetch(`/calls/${callId}`)
+    getCall(callId)
       .then((data) => {
         setCall(data);
         show("Call loaded");

--- a/frontend/src/routes/CallsPage.tsx
+++ b/frontend/src/routes/CallsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useToast } from "../context/ToastProvider";
-import { apiFetch } from "../lib/api";
+import { getCalls } from "../lib/api/calls";
 
 
 interface Call {
@@ -17,7 +17,7 @@ export default function CallsPage() {
   useEffect(() => {
     setLoading(true);
     setError(null);
-    apiFetch("/calls")
+    getCalls()
       .then((data) => {
         setCalls(data);
         show("Calls loaded");

--- a/frontend/src/routes/DashboardPage.tsx
+++ b/frontend/src/routes/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import Card from "../components/ui/Card";
 import { apiFetch } from "../lib/api";
+import { getCalls } from "../lib/api/calls";
 
 export default function DashboardPage() {
   const [stats, setStats] = useState({ calls: 0, applications: 0 });
@@ -8,7 +9,7 @@ export default function DashboardPage() {
   useEffect(() => {
     async function load() {
       try {
-        const calls = await apiFetch("/calls");
+        const calls = await getCalls();
         const apps = await apiFetch("/applications");
         setStats({ calls: calls.length, applications: apps.length });
       } catch {

--- a/frontend/src/routes/calls/apply/ApplicationLayout.tsx
+++ b/frontend/src/routes/calls/apply/ApplicationLayout.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { Outlet, useParams } from "react-router-dom";
 import { useToast } from "../../../context/ToastProvider";
-import { apiFetch } from "../../../lib/api";
 import { getCall } from "../../../lib/api/calls";
 import Stepper, { Step } from "../../../components/common/Stepper";
 import { ApplicationProvider } from "../../../context/ApplicationProvider";
@@ -24,7 +23,7 @@ export default function ApplicationLayout() {
     if (!callId) return;
     setLoading(true);
     setError(null);
-    apiFetch(`/calls/${callId}`)
+    getCall(callId)
       .then(() => show("Call info loaded"))
       .catch((err) => {
         setError(err.message);
@@ -32,13 +31,6 @@ export default function ApplicationLayout() {
       })
       .finally(() => setLoading(false));
   }, [callId, show]);
-  const [call, setCall] = useState<any>();
-
-  useEffect(() => {
-    if (callId) {
-      getCall(callId).then(setCall).catch(() => setCall(undefined));
-    }
-  }, [callId]);
 
 
   if (!callId) return null;


### PR DESCRIPTION
## Summary
- use `getCall` and `getCalls` helpers throughout the front-end
- drop redundant fetch in `ApplicationLayout`

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6851cd18da3c832c962f133ad6b93c2a