### PR TITLE
Define shared Call type for frontend

### DIFF
--- a/frontend/src/context/ApplicationProvider.tsx
+++ b/frontend/src/context/ApplicationProvider.tsx
@@ -1,12 +1,7 @@
 import { createContext, useContext, useEffect, useState, ReactNode } from "react";
 import { apiFetch } from "../lib/api";
 import { getCall } from "../lib/api/calls";
-
-interface Call {
-  id: string;
-  title?: string;
-  description?: string | null;
-}
+import { Call } from "../types";
 
 interface Attachment {
   id: string;

--- a/frontend/src/routes/CallManagementPage.tsx
+++ b/frontend/src/routes/CallManagementPage.tsx
@@ -4,12 +4,7 @@ import Input from "../components/ui/Input";
 import Table from "../components/ui/Table";
 import { apiFetch } from "../lib/api";
 import { getCalls } from "../lib/api/calls";
-
-interface Call {
-  id: string;
-  title: string;
-  description?: string;
-}
+import { Call } from "../types";
 
 export default function CallManagementPage() {
   const [calls, setCalls] = useState<Call[]>([]);

--- a/frontend/src/routes/CallPreviewPage.tsx
+++ b/frontend/src/routes/CallPreviewPage.tsx
@@ -2,11 +2,7 @@ import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useToast } from "../context/ToastProvider";
 import { getCall } from "../lib/api/calls";
-
-interface Call {
-  id: string;
-  title: string;
-}
+import { Call } from "../types";
 
 export default function CallPreviewPage() {
   const { callId } = useParams<{ callId: string }>();

--- a/frontend/src/routes/CallsPage.tsx
+++ b/frontend/src/routes/CallsPage.tsx
@@ -1,12 +1,7 @@
 import { useEffect, useState } from "react";
 import { useToast } from "../context/ToastProvider";
 import { getCalls } from "../lib/api/calls";
-
-
-interface Call {
-  id: string;
-  title: string;
-}
+import { Call } from "../types";
 
 export default function CallsPage() {
   const { show } = useToast();

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4,3 +4,9 @@ export enum UserRole {
   admin = 'admin',
   super_admin = 'super_admin',
 }
+
+export interface Call {
+  id: string;
+  title?: string;
+  description?: string | null;
+}


### PR DESCRIPTION
## Summary
- add a `Call` interface to `src/types.ts`
- use the shared `Call` type across route pages and ApplicationProvider

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6851d3647bc8832cb31b80709bde235f