### PR TITLE
Refactor login page to use auth context

### DIFF
--- a/frontend/src/routes/LoginPage.tsx
+++ b/frontend/src/routes/LoginPage.tsx
@@ -2,12 +2,12 @@ import { useState } from "react";
 import Button from "../components/ui/Button";
 import Input from "../components/ui/Input";
 import { useToast } from "../context/ToastProvider";
-import { apiFetch } from "../lib/api";
-import { login } from "../lib/api/auth";
+import { useAuth } from "../context/AuthProvider";
 
 
 export default function LoginPage() {
   const { show } = useToast();
+  const { login } = useAuth();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
@@ -17,12 +17,7 @@ export default function LoginPage() {
     setLoading(true);
     setError(null);
     try {
-      const data = await apiFetch("/auth/login", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email, password }),
-      });
-      localStorage.setItem("token", data.access_token);
+      await login(email, password);
       show("Logged in successfully");
     } catch (err) {
       setError((err as Error).message);


### PR DESCRIPTION
## Summary
- integrate `useAuth()` into `LoginPage`
- remove the unused API login calls and rely on context

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6851d36f9bc8832cbb12abea6b063c43