### PR TITLE
Render login errors and disable button while loading

### DIFF
--- a/frontend/src/routes/LoginPage.tsx
+++ b/frontend/src/routes/LoginPage.tsx
@@ -37,7 +37,10 @@ export default function LoginPage() {
       <h1>Login</h1>
       <Input placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
       <Input type="password" placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} />
-      <Button onClick={handleLogin}>Login</Button>
+      <Button onClick={handleLogin} disabled={loading}>
+        {loading ? "Loading..." : "Login"}
+      </Button>
+      {error && <div className="text-red-500">Error: {error}</div>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- display login error text under form
- disable login button while request is loading

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6851d3733498832cad2b0b8d5160299d