### PR TITLE
Fix unused import in DocumentList

### DIFF
--- a/frontend/src/components/DocumentList.tsx
+++ b/frontend/src/components/DocumentList.tsx
@@ -1,4 +1,3 @@
-import { ReactNode } from "react";
 
 export interface DocumentItem {
   id: string;


### PR DESCRIPTION
## Summary
- remove an unused `ReactNode` import from `DocumentList.tsx`

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6851d377c9b0832ca5f27b353459d0d9