### PR TITLE
Use application context submit function

### DIFF
--- a/frontend/src/routes/calls/apply/Step4_Submit.tsx
+++ b/frontend/src/routes/calls/apply/Step4_Submit.tsx
@@ -1,26 +1,20 @@
 
 import { useState } from "react";
-import { useParams } from "react-router-dom";
 import Button from "../../../components/ui/Button";
 import { useToast } from "../../../context/ToastProvider";
-import { apiFetch } from "../../../lib/api";
+import { useApplication } from "../../../context/ApplicationProvider";
 
 export default function Step4_Submit() {
-  const { callId } = useParams<{ callId: string }>();
+  const { submitApplication } = useApplication();
   const { show } = useToast();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const handleSubmit = async () => {
-    if (!callId) return;
     setLoading(true);
     setError(null);
     try {
-      await apiFetch("/applications", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ call_id: callId }),
-      });
+      await submitApplication();
       show("Application submitted");
     } catch (err) {
       setError((err as Error).message);


### PR DESCRIPTION
## Summary
- use `submitApplication` from context instead of posting manually

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6851d380e47c832c9a4041963b354ef1