### PR TITLE
Remove redundant call fetch logic

### DIFF
--- a/frontend/src/routes/calls/apply/ApplicationLayout.tsx
+++ b/frontend/src/routes/calls/apply/ApplicationLayout.tsx
@@ -1,7 +1,4 @@
-import { useEffect, useState } from "react";
 import { Outlet, useParams } from "react-router-dom";
-import { useToast } from "../../../context/ToastProvider";
-import { getCall } from "../../../lib/api/calls";
 import Stepper, { Step } from "../../../components/common/Stepper";
 import { ApplicationProvider } from "../../../context/ApplicationProvider";
 
@@ -15,31 +12,12 @@ const steps: Step[] = [
 
 export default function ApplicationLayout() {
   const { callId } = useParams<{ callId: string }>();
-  const { show } = useToast();
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!callId) return;
-    setLoading(true);
-    setError(null);
-    getCall(callId)
-      .then(() => show("Call info loaded"))
-      .catch((err) => {
-        setError(err.message);
-        show("Failed to load call");
-      })
-      .finally(() => setLoading(false));
-  }, [callId, show]);
-
 
   if (!callId) return null;
 
   return (
     <ApplicationProvider callId={callId}>
       <div className="p-4">
-        {loading && <div>Loading...</div>}
-        {error && <div className="text-red-500">Error: {error}</div>}
         <Stepper steps={steps} />
         <Outlet />
       </div>


### PR DESCRIPTION
## Summary
- remove unused loading state and duplicated getCall logic
- depend on ApplicationProvider for call information

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6851d3873108832c88916472e1012ec1