### PR TITLE
Remove numbered comments from models

### DIFF
--- a/backend/app/models/academic_reference.py
+++ b/backend/app/models/academic_reference.py
@@ -12,4 +12,3 @@ class AcademicReference(Base, SoftDeleteMixin):
     application_form = relationship('ApplicationForm', back_populates='academic_references')
 
 
-# 8. Suggested References & Mobility

--- a/backend/app/models/application_form.py
+++ b/backend/app/models/application_form.py
@@ -82,4 +82,3 @@ class ApplicationForm(Base, SoftDeleteMixin):
     security_answers = relationship('SecurityAnswer', back_populates='application_form')
 
 
-# 7. Academic portfolio details

--- a/backend/app/models/application_info.py
+++ b/backend/app/models/application_info.py
@@ -17,4 +17,3 @@ class ApplicationInfo(Base, SoftDeleteMixin):
     application = relationship('Application', back_populates='info')
 
 
-# 6. Application Forms

--- a/backend/app/models/attachment.py
+++ b/backend/app/models/attachment.py
@@ -13,4 +13,3 @@ class Attachment(Base, SoftDeleteMixin):
     application = relationship('Application', back_populates='attachments')
 
 
-# 5. Application Info

--- a/backend/app/models/call_security_question.py
+++ b/backend/app/models/call_security_question.py
@@ -10,4 +10,3 @@ class CallSecurityQuestion(Base, SoftDeleteMixin):
     call = relationship('Call', back_populates='security_questions')
 
 
-# 4. Applications and attachments

--- a/backend/app/models/call_supervisor.py
+++ b/backend/app/models/call_supervisor.py
@@ -10,4 +10,3 @@ class CallSupervisor(Base, SoftDeleteMixin):
     supervisor = relationship('Supervisor', back_populates='call_links')
 
 
-# 3. Ethics/Security question pools

--- a/backend/app/models/ethical_optional_table.py
+++ b/backend/app/models/ethical_optional_table.py
@@ -11,4 +11,3 @@ class EthicalOptionalTable(Base, SoftDeleteMixin):
     application_form = relationship('ApplicationForm', back_populates='ethical_optional_tables')
 
 
-# 10. Security tables

--- a/backend/app/models/mobility_entry.py
+++ b/backend/app/models/mobility_entry.py
@@ -12,4 +12,3 @@ class MobilityEntry(Base, SoftDeleteMixin):
     application_form = relationship('ApplicationForm', back_populates='mobility_entries')
 
 
-# 9. Ethics tables

--- a/backend/app/models/security_answer.py
+++ b/backend/app/models/security_answer.py
@@ -9,4 +9,3 @@ class SecurityAnswer(Base, SoftDeleteMixin):
     application_form = relationship('ApplicationForm', back_populates='security_answers')
 
 
-# 11. Review Reports

--- a/backend/app/models/supervisor.py
+++ b/backend/app/models/supervisor.py
@@ -13,4 +13,3 @@ class Supervisor(Base, SoftDeleteMixin):
     call_links = relationship('CallSupervisor', back_populates='supervisor')
 
 
-# 2. Calls and Templates


### PR DESCRIPTION
## Summary
- clean up leftover numbered comments in backend models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851d39eac64832ca1a026f065d2f4a6