### PR TITLE
Restrict call management routes to admins

### DIFF
--- a/backend/app/routes/call_ethics_question.py
+++ b/backend/app/routes/call_ethics_question.py
@@ -2,6 +2,9 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 import uuid
 
+from ..core.security import role_required
+from ..core.enums import UserRole
+
 from ..database import get_db
 from ..crud import call_ethics_question as crud
 from ..schemas import CallEthicsQuestionCreate, CallEthicsQuestionRead
@@ -9,10 +12,12 @@ from ..schemas import CallEthicsQuestionCreate, CallEthicsQuestionRead
 router = APIRouter(prefix="/call_ethics_questions", tags=["CallEthicsQuestion"])
 
 @router.post('/', response_model=CallEthicsQuestionRead)
+@role_required(UserRole.admin, UserRole.super_admin)
 def create_call_ethics_question(data: CallEthicsQuestionCreate, db: Session = Depends(get_db)):
     return crud.create(db, data.dict())
 
 @router.get('/{obj_id}', response_model=CallEthicsQuestionRead)
+@role_required(UserRole.admin, UserRole.super_admin)
 def read_call_ethics_question(obj_id: uuid.UUID, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
@@ -20,10 +25,12 @@ def read_call_ethics_question(obj_id: uuid.UUID, db: Session = Depends(get_db)):
     return obj
 
 @router.get('/', response_model=list[CallEthicsQuestionRead])
+@role_required(UserRole.admin, UserRole.super_admin)
 def read_call_ethics_questions(db: Session = Depends(get_db)):
     return list(crud.get_all(db))
 
 @router.put('/{obj_id}', response_model=CallEthicsQuestionRead)
+@role_required(UserRole.admin, UserRole.super_admin)
 def update_call_ethics_question(obj_id: uuid.UUID, data: CallEthicsQuestionCreate, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
@@ -31,6 +38,7 @@ def update_call_ethics_question(obj_id: uuid.UUID, data: CallEthicsQuestionCreat
     return crud.update(db, obj, data.dict())
 
 @router.delete('/{obj_id}')
+@role_required(UserRole.admin, UserRole.super_admin)
 def delete_call_ethics_question(obj_id: uuid.UUID, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)
     if not obj:

--- a/backend/app/routes/call_institution.py
+++ b/backend/app/routes/call_institution.py
@@ -2,6 +2,9 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 import uuid
 
+from ..core.security import role_required
+from ..core.enums import UserRole
+
 from ..database import get_db
 from ..crud import call_institution as crud
 from ..schemas import CallInstitutionCreate, CallInstitutionRead
@@ -9,10 +12,12 @@ from ..schemas import CallInstitutionCreate, CallInstitutionRead
 router = APIRouter(prefix="/call_institutions", tags=["CallInstitution"])
 
 @router.post('/', response_model=CallInstitutionRead)
+@role_required(UserRole.admin, UserRole.super_admin)
 def create_call_institution(data: CallInstitutionCreate, db: Session = Depends(get_db)):
     return crud.create(db, data.dict())
 
 @router.get('/{obj_id}', response_model=CallInstitutionRead)
+@role_required(UserRole.admin, UserRole.super_admin)
 def read_call_institution(obj_id: uuid.UUID, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
@@ -20,10 +25,12 @@ def read_call_institution(obj_id: uuid.UUID, db: Session = Depends(get_db)):
     return obj
 
 @router.get('/', response_model=list[CallInstitutionRead])
+@role_required(UserRole.admin, UserRole.super_admin)
 def read_call_institutions(db: Session = Depends(get_db)):
     return list(crud.get_all(db))
 
 @router.put('/{obj_id}', response_model=CallInstitutionRead)
+@role_required(UserRole.admin, UserRole.super_admin)
 def update_call_institution(obj_id: uuid.UUID, data: CallInstitutionCreate, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
@@ -31,6 +38,7 @@ def update_call_institution(obj_id: uuid.UUID, data: CallInstitutionCreate, db: 
     return crud.update(db, obj, data.dict())
 
 @router.delete('/{obj_id}')
+@role_required(UserRole.admin, UserRole.super_admin)
 def delete_call_institution(obj_id: uuid.UUID, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)
     if not obj:

--- a/backend/app/routes/call_required_document.py
+++ b/backend/app/routes/call_required_document.py
@@ -2,6 +2,9 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 import uuid
 
+from ..core.security import role_required
+from ..core.enums import UserRole
+
 from ..database import get_db
 from ..crud import call_required_document as crud
 from ..schemas import CallRequiredDocumentCreate, CallRequiredDocumentRead
@@ -9,10 +12,12 @@ from ..schemas import CallRequiredDocumentCreate, CallRequiredDocumentRead
 router = APIRouter(prefix="/call_required_documents", tags=["CallRequiredDocument"])
 
 @router.post('/', response_model=CallRequiredDocumentRead)
+@role_required(UserRole.admin, UserRole.super_admin)
 def create_call_required_document(data: CallRequiredDocumentCreate, db: Session = Depends(get_db)):
     return crud.create(db, data.dict())
 
 @router.get('/{obj_id}', response_model=CallRequiredDocumentRead)
+@role_required(UserRole.admin, UserRole.super_admin)
 def read_call_required_document(obj_id: uuid.UUID, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
@@ -20,10 +25,12 @@ def read_call_required_document(obj_id: uuid.UUID, db: Session = Depends(get_db)
     return obj
 
 @router.get('/', response_model=list[CallRequiredDocumentRead])
+@role_required(UserRole.admin, UserRole.super_admin)
 def read_call_required_documents(db: Session = Depends(get_db)):
     return list(crud.get_all(db))
 
 @router.put('/{obj_id}', response_model=CallRequiredDocumentRead)
+@role_required(UserRole.admin, UserRole.super_admin)
 def update_call_required_document(obj_id: uuid.UUID, data: CallRequiredDocumentCreate, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
@@ -31,6 +38,7 @@ def update_call_required_document(obj_id: uuid.UUID, data: CallRequiredDocumentC
     return crud.update(db, obj, data.dict())
 
 @router.delete('/{obj_id}')
+@role_required(UserRole.admin, UserRole.super_admin)
 def delete_call_required_document(obj_id: uuid.UUID, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)
     if not obj:

--- a/backend/app/routes/call_security_question.py
+++ b/backend/app/routes/call_security_question.py
@@ -2,6 +2,9 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 import uuid
 
+from ..core.security import role_required
+from ..core.enums import UserRole
+
 from ..database import get_db
 from ..crud import call_security_question as crud
 from ..schemas import CallSecurityQuestionCreate, CallSecurityQuestionRead
@@ -9,10 +12,12 @@ from ..schemas import CallSecurityQuestionCreate, CallSecurityQuestionRead
 router = APIRouter(prefix="/call_security_questions", tags=["CallSecurityQuestion"])
 
 @router.post('/', response_model=CallSecurityQuestionRead)
+@role_required(UserRole.admin, UserRole.super_admin)
 def create_call_security_question(data: CallSecurityQuestionCreate, db: Session = Depends(get_db)):
     return crud.create(db, data.dict())
 
 @router.get('/{obj_id}', response_model=CallSecurityQuestionRead)
+@role_required(UserRole.admin, UserRole.super_admin)
 def read_call_security_question(obj_id: uuid.UUID, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
@@ -20,10 +25,12 @@ def read_call_security_question(obj_id: uuid.UUID, db: Session = Depends(get_db)
     return obj
 
 @router.get('/', response_model=list[CallSecurityQuestionRead])
+@role_required(UserRole.admin, UserRole.super_admin)
 def read_call_security_questions(db: Session = Depends(get_db)):
     return list(crud.get_all(db))
 
 @router.put('/{obj_id}', response_model=CallSecurityQuestionRead)
+@role_required(UserRole.admin, UserRole.super_admin)
 def update_call_security_question(obj_id: uuid.UUID, data: CallSecurityQuestionCreate, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
@@ -31,6 +38,7 @@ def update_call_security_question(obj_id: uuid.UUID, data: CallSecurityQuestionC
     return crud.update(db, obj, data.dict())
 
 @router.delete('/{obj_id}')
+@role_required(UserRole.admin, UserRole.super_admin)
 def delete_call_security_question(obj_id: uuid.UUID, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)
     if not obj:

--- a/backend/app/routes/call_supervisor.py
+++ b/backend/app/routes/call_supervisor.py
@@ -2,6 +2,9 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 import uuid
 
+from ..core.security import role_required
+from ..core.enums import UserRole
+
 from ..database import get_db
 from ..crud import call_supervisor as crud
 from ..schemas import CallSupervisorCreate, CallSupervisorRead
@@ -9,10 +12,12 @@ from ..schemas import CallSupervisorCreate, CallSupervisorRead
 router = APIRouter(prefix="/call_supervisors", tags=["CallSupervisor"])
 
 @router.post('/', response_model=CallSupervisorRead)
+@role_required(UserRole.admin, UserRole.super_admin)
 def create_call_supervisor(data: CallSupervisorCreate, db: Session = Depends(get_db)):
     return crud.create(db, data.dict())
 
 @router.get('/{obj_id}', response_model=CallSupervisorRead)
+@role_required(UserRole.admin, UserRole.super_admin)
 def read_call_supervisor(obj_id: uuid.UUID, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
@@ -20,10 +25,12 @@ def read_call_supervisor(obj_id: uuid.UUID, db: Session = Depends(get_db)):
     return obj
 
 @router.get('/', response_model=list[CallSupervisorRead])
+@role_required(UserRole.admin, UserRole.super_admin)
 def read_call_supervisors(db: Session = Depends(get_db)):
     return list(crud.get_all(db))
 
 @router.put('/{obj_id}', response_model=CallSupervisorRead)
+@role_required(UserRole.admin, UserRole.super_admin)
 def update_call_supervisor(obj_id: uuid.UUID, data: CallSupervisorCreate, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
@@ -31,6 +38,7 @@ def update_call_supervisor(obj_id: uuid.UUID, data: CallSupervisorCreate, db: Se
     return crud.update(db, obj, data.dict())
 
 @router.delete('/{obj_id}')
+@role_required(UserRole.admin, UserRole.super_admin)
 def delete_call_supervisor(obj_id: uuid.UUID, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)
     if not obj:

--- a/backend/app/routes/call_template.py
+++ b/backend/app/routes/call_template.py
@@ -2,6 +2,9 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 import uuid
 
+from ..core.security import role_required
+from ..core.enums import UserRole
+
 from ..database import get_db
 from ..crud import call_template as crud
 from ..schemas import CallTemplateCreate, CallTemplateRead
@@ -9,10 +12,12 @@ from ..schemas import CallTemplateCreate, CallTemplateRead
 router = APIRouter(prefix="/call_templates", tags=["CallTemplate"])
 
 @router.post('/', response_model=CallTemplateRead)
+@role_required(UserRole.admin, UserRole.super_admin)
 def create_call_template(data: CallTemplateCreate, db: Session = Depends(get_db)):
     return crud.create(db, data.dict())
 
 @router.get('/{obj_id}', response_model=CallTemplateRead)
+@role_required(UserRole.admin, UserRole.super_admin)
 def read_call_template(obj_id: uuid.UUID, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
@@ -20,10 +25,12 @@ def read_call_template(obj_id: uuid.UUID, db: Session = Depends(get_db)):
     return obj
 
 @router.get('/', response_model=list[CallTemplateRead])
+@role_required(UserRole.admin, UserRole.super_admin)
 def read_call_templates(db: Session = Depends(get_db)):
     return list(crud.get_all(db))
 
 @router.put('/{obj_id}', response_model=CallTemplateRead)
+@role_required(UserRole.admin, UserRole.super_admin)
 def update_call_template(obj_id: uuid.UUID, data: CallTemplateCreate, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
@@ -31,6 +38,7 @@ def update_call_template(obj_id: uuid.UUID, data: CallTemplateCreate, db: Sessio
     return crud.update(db, obj, data.dict())
 
 @router.delete('/{obj_id}')
+@role_required(UserRole.admin, UserRole.super_admin)
 def delete_call_template(obj_id: uuid.UUID, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)
     if not obj:

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,8 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_call_templates_requires_auth():
+    response = client.get('/call_templates')
+    assert response.status_code in {401, 403}


### PR DESCRIPTION
## Summary
- secure call management endpoints with `role_required`
- add basic auth test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6851d392c2d8832cbe593299a35fc10f