### PR TITLE
Remove unused useParams import

### DIFF
--- a/frontend/src/routes/calls/apply/Step4_Submit.tsx
+++ b/frontend/src/routes/calls/apply/Step4_Submit.tsx
@@ -1,6 +1,5 @@
 
 import { useState } from "react";
-import { useParams } from "react-router-dom";
 import { Button } from "../../../components/ui/Button";
 import { useToast } from "../../../context/ToastProvider";
 import { useApplication } from "../../../context/ApplicationProvider";


### PR DESCRIPTION
## Summary
- remove leftover `useParams` import from `Step4_Submit`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6851de196b84832cb6b309cb9fce7a8e