### PR TITLE
Fix router compatibility and show navbar on auth pages

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-fastapi
+fastapi>=0.111
 uvicorn
 sqlalchemy
 pydantic

--- a/frontend/src/routes/LoginPage.tsx
+++ b/frontend/src/routes/LoginPage.tsx
@@ -3,6 +3,7 @@ import { Button } from "../components/ui/Button";
 import { Input } from "../components/ui/Input";
 import { useToast } from "../context/ToastProvider";
 import { useAuth } from "../context/AuthProvider";
+import Navbar from "../components/layout/Navbar";
 
 
 export default function LoginPage() {
@@ -28,14 +29,26 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="space-y-2 p-4">
-      <h1>Login</h1>
-      <Input placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
-      <Input type="password" placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} />
-      <Button onClick={handleLogin} disabled={loading}>
-        {loading ? "Loading..." : "Login"}
-      </Button>
-      {error && <div className="text-red-500">Error: {error}</div>}
-    </div>
+    <>
+      <Navbar />
+      <div className="space-y-2 p-4">
+        <h1>Login</h1>
+        <Input
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <Input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <Button onClick={handleLogin} disabled={loading}>
+          {loading ? "Loading..." : "Login"}
+        </Button>
+        {error && <div className="text-red-500">Error: {error}</div>}
+      </div>
+    </>
   );
 }

--- a/frontend/src/routes/RegisterPage.tsx
+++ b/frontend/src/routes/RegisterPage.tsx
@@ -4,6 +4,7 @@ import  { Button } from "../components/ui/Button";
 import { Input } from "../components/ui/Input";
 import { useToast } from "../context/ToastProvider";
 import { useAuth } from "../context/AuthProvider";
+import Navbar from "../components/layout/Navbar";
 
 export default function RegisterPage() {
   const { show } = useToast();
@@ -23,11 +24,23 @@ export default function RegisterPage() {
   };
 
   return (
-    <div className="space-y-2 p-4">
-      <h1>Register</h1>
-      <Input placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
-      <Input type="password" placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} />
-      <Button onClick={handleRegister}>Register</Button>
-    </div>
+    <>
+      <Navbar />
+      <div className="space-y-2 p-4">
+        <h1>Register</h1>
+        <Input
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <Input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <Button onClick={handleRegister}>Register</Button>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- require a FastAPI version that supports `trailing_slash`
- show the Navbar component on Login and Register pages so navigation is always visible

## Testing
- `pytest -q` *(fails: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6851e1ce2eac832c8256381964410923