### PR TITLE
Fix router initialization for fastapi

### DIFF
--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -34,7 +34,7 @@ from . import (
 
 from fastapi import APIRouter
 
-api_router = APIRouter(trailing_slash=False)
+api_router = APIRouter()
 
 api_router.include_router(academic_portfolio.router)
 api_router.include_router(academic_reference.router)

--- a/backend/app/routes/academic_portfolio.py
+++ b/backend/app/routes/academic_portfolio.py
@@ -6,7 +6,7 @@ from ..database import get_db
 from ..crud import academic_portfolio as crud
 from ..schemas import AcademicPortfolioCreate, AcademicPortfolioRead
 
-router = APIRouter(trailing_slash=False, prefix="/academic_portfolios", tags=["AcademicPortfolio"])
+router = APIRouter(prefix="/academic_portfolios", tags=["AcademicPortfolio"])
 
 @router.post('/', response_model=AcademicPortfolioRead)
 def create_academic_portfolio(data: AcademicPortfolioCreate, db: Session = Depends(get_db)):

--- a/backend/app/routes/academic_reference.py
+++ b/backend/app/routes/academic_reference.py
@@ -6,7 +6,7 @@ from ..database import get_db
 from ..crud import academic_reference as crud
 from ..schemas import AcademicReferenceCreate, AcademicReferenceRead
 
-router = APIRouter(trailing_slash=False, prefix="/academic_references", tags=["AcademicReference"])
+router = APIRouter(prefix="/academic_references", tags=["AcademicReference"])
 
 @router.post('/', response_model=AcademicReferenceRead)
 def create_academic_reference(data: AcademicReferenceCreate, db: Session = Depends(get_db)):

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -7,7 +7,7 @@ from ..schemas import CallRead
 from ..core.security import role_required
 from ..core.enums import UserRole
 
-router = APIRouter(trailing_slash=False, prefix="/admin", tags=["Admin"])
+router = APIRouter(prefix="/admin", tags=["Admin"])
 
 
 @router.get("/calls", response_model=list[CallRead])

--- a/backend/app/routes/application.py
+++ b/backend/app/routes/application.py
@@ -7,7 +7,7 @@ from ..crud import application as crud
 from ..schemas import ApplicationCreate, ApplicationRead
 from ..core.security import get_current_user
 
-router = APIRouter(trailing_slash=False, prefix="/applications", tags=["Application"])
+router = APIRouter(prefix="/applications", tags=["Application"])
 
 @router.post('/', response_model=ApplicationRead)
 def create_application(

--- a/backend/app/routes/application_form.py
+++ b/backend/app/routes/application_form.py
@@ -6,7 +6,7 @@ from ..database import get_db
 from ..crud import application_form as crud
 from ..schemas import ApplicationFormCreate, ApplicationFormRead
 
-router = APIRouter(trailing_slash=False, prefix="/application_forms", tags=["ApplicationForm"])
+router = APIRouter(prefix="/application_forms", tags=["ApplicationForm"])
 
 @router.post('/', response_model=ApplicationFormRead)
 def create_application_form(data: ApplicationFormCreate, db: Session = Depends(get_db)):

--- a/backend/app/routes/application_info.py
+++ b/backend/app/routes/application_info.py
@@ -6,7 +6,7 @@ from ..database import get_db
 from ..crud import application_info as crud
 from ..schemas import ApplicationInfoCreate, ApplicationInfoRead
 
-router = APIRouter(trailing_slash=False, prefix="/application_infos", tags=["ApplicationInfo"])
+router = APIRouter(prefix="/application_infos", tags=["ApplicationInfo"])
 
 @router.post('/', response_model=ApplicationInfoRead)
 def create_application_info(data: ApplicationInfoCreate, db: Session = Depends(get_db)):

--- a/backend/app/routes/attachment.py
+++ b/backend/app/routes/attachment.py
@@ -6,7 +6,7 @@ from ..database import get_db
 from ..crud import attachment as crud
 from ..schemas import AttachmentCreate, AttachmentRead
 
-router = APIRouter(trailing_slash=False, prefix="/attachments", tags=["Attachment"])
+router = APIRouter(prefix="/attachments", tags=["Attachment"])
 
 
 @router.get('/application/{application_id}', response_model=list[AttachmentRead])

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -7,7 +7,7 @@ from ..crud import user as crud_user
 from ..schemas import UserCreate, UserRead, Token
 from ..core.security import verify_password, create_access_token
 
-router = APIRouter(trailing_slash=False, prefix="/auth", tags=["Auth"])
+router = APIRouter(prefix="/auth", tags=["Auth"])
 
 
 class LoginData(BaseModel):

--- a/backend/app/routes/call.py
+++ b/backend/app/routes/call.py
@@ -9,7 +9,7 @@ from ..database import get_db
 from ..crud import call as crud
 from ..schemas import CallCreate, CallRead
 
-router = APIRouter(trailing_slash=False, prefix="/calls", tags=["Call"])
+router = APIRouter(prefix="/calls", tags=["Call"])
 
 @router.post('/', response_model=CallRead)
 @role_required(UserRole.admin, UserRole.super_admin)

--- a/backend/app/routes/call_ethics_question.py
+++ b/backend/app/routes/call_ethics_question.py
@@ -9,7 +9,7 @@ from ..database import get_db
 from ..crud import call_ethics_question as crud
 from ..schemas import CallEthicsQuestionCreate, CallEthicsQuestionRead
 
-router = APIRouter(trailing_slash=False, prefix="/call_ethics_questions", tags=["CallEthicsQuestion"])
+router = APIRouter(prefix="/call_ethics_questions", tags=["CallEthicsQuestion"])
 
 @router.post('/', response_model=CallEthicsQuestionRead)
 @role_required(UserRole.admin, UserRole.super_admin)

--- a/backend/app/routes/call_institution.py
+++ b/backend/app/routes/call_institution.py
@@ -9,7 +9,7 @@ from ..database import get_db
 from ..crud import call_institution as crud
 from ..schemas import CallInstitutionCreate, CallInstitutionRead
 
-router = APIRouter(trailing_slash=False, prefix="/call_institutions", tags=["CallInstitution"])
+router = APIRouter(prefix="/call_institutions", tags=["CallInstitution"])
 
 @router.post('/', response_model=CallInstitutionRead)
 @role_required(UserRole.admin, UserRole.super_admin)

--- a/backend/app/routes/call_required_document.py
+++ b/backend/app/routes/call_required_document.py
@@ -9,7 +9,7 @@ from ..database import get_db
 from ..crud import call_required_document as crud
 from ..schemas import CallRequiredDocumentCreate, CallRequiredDocumentRead
 
-router = APIRouter(trailing_slash=False, prefix="/call_required_documents", tags=["CallRequiredDocument"])
+router = APIRouter(prefix="/call_required_documents", tags=["CallRequiredDocument"])
 
 @router.post('/', response_model=CallRequiredDocumentRead)
 @role_required(UserRole.admin, UserRole.super_admin)

--- a/backend/app/routes/call_security_question.py
+++ b/backend/app/routes/call_security_question.py
@@ -9,7 +9,7 @@ from ..database import get_db
 from ..crud import call_security_question as crud
 from ..schemas import CallSecurityQuestionCreate, CallSecurityQuestionRead
 
-router = APIRouter(trailing_slash=False, prefix="/call_security_questions", tags=["CallSecurityQuestion"])
+router = APIRouter(prefix="/call_security_questions", tags=["CallSecurityQuestion"])
 
 @router.post('/', response_model=CallSecurityQuestionRead)
 @role_required(UserRole.admin, UserRole.super_admin)

--- a/backend/app/routes/call_supervisor.py
+++ b/backend/app/routes/call_supervisor.py
@@ -9,7 +9,7 @@ from ..database import get_db
 from ..crud import call_supervisor as crud
 from ..schemas import CallSupervisorCreate, CallSupervisorRead
 
-router = APIRouter(trailing_slash=False, prefix="/call_supervisors", tags=["CallSupervisor"])
+router = APIRouter(prefix="/call_supervisors", tags=["CallSupervisor"])
 
 @router.post('/', response_model=CallSupervisorRead)
 @role_required(UserRole.admin, UserRole.super_admin)

--- a/backend/app/routes/call_template.py
+++ b/backend/app/routes/call_template.py
@@ -9,7 +9,7 @@ from ..database import get_db
 from ..crud import call_template as crud
 from ..schemas import CallTemplateCreate, CallTemplateRead
 
-router = APIRouter(trailing_slash=False, prefix="/call_templates", tags=["CallTemplate"])
+router = APIRouter(prefix="/call_templates", tags=["CallTemplate"])
 
 @router.post('/', response_model=CallTemplateRead)
 @role_required(UserRole.admin, UserRole.super_admin)

--- a/backend/app/routes/ethical_optional_table.py
+++ b/backend/app/routes/ethical_optional_table.py
@@ -6,7 +6,7 @@ from ..database import get_db
 from ..crud import ethical_optional_table as crud
 from ..schemas import EthicalOptionalTableCreate, EthicalOptionalTableRead
 
-router = APIRouter(trailing_slash=False, prefix="/ethical_optional_tables", tags=["EthicalOptionalTable"])
+router = APIRouter(prefix="/ethical_optional_tables", tags=["EthicalOptionalTable"])
 
 @router.post('/', response_model=EthicalOptionalTableRead)
 def create_ethical_optional_table(data: EthicalOptionalTableCreate, db: Session = Depends(get_db)):

--- a/backend/app/routes/ethics_answer.py
+++ b/backend/app/routes/ethics_answer.py
@@ -6,7 +6,7 @@ from ..database import get_db
 from ..crud import ethics_answer as crud
 from ..schemas import EthicsAnswerCreate, EthicsAnswerRead
 
-router = APIRouter(trailing_slash=False, prefix="/ethics_answers", tags=["EthicsAnswer"])
+router = APIRouter(prefix="/ethics_answers", tags=["EthicsAnswer"])
 
 @router.post('/', response_model=EthicsAnswerRead)
 def create_ethics_answer(data: EthicsAnswerCreate, db: Session = Depends(get_db)):

--- a/backend/app/routes/ethics_issue.py
+++ b/backend/app/routes/ethics_issue.py
@@ -6,7 +6,7 @@ from ..database import get_db
 from ..crud import ethics_issue as crud
 from ..schemas import EthicsIssueCreate, EthicsIssueRead
 
-router = APIRouter(trailing_slash=False, prefix="/ethics_issues", tags=["EthicsIssue"])
+router = APIRouter(prefix="/ethics_issues", tags=["EthicsIssue"])
 
 @router.post('/', response_model=EthicsIssueRead)
 def create_ethics_issue(data: EthicsIssueCreate, db: Session = Depends(get_db)):

--- a/backend/app/routes/ethics_meta.py
+++ b/backend/app/routes/ethics_meta.py
@@ -6,7 +6,7 @@ from ..database import get_db
 from ..crud import ethics_meta as crud
 from ..schemas import EthicsMetaCreate, EthicsMetaRead
 
-router = APIRouter(trailing_slash=False, prefix="/ethics_metas", tags=["EthicsMeta"])
+router = APIRouter(prefix="/ethics_metas", tags=["EthicsMeta"])
 
 @router.post('/', response_model=EthicsMetaRead)
 def create_ethics_meta(data: EthicsMetaCreate, db: Session = Depends(get_db)):

--- a/backend/app/routes/file.py
+++ b/backend/app/routes/file.py
@@ -9,7 +9,7 @@ from ..models import User
 from ..crud import application as crud_application, attachment as crud_attachment
 from ..core.enums import UserRole
 
-router = APIRouter(trailing_slash=False, tags=["File"])
+router = APIRouter(tags=["File"])
 
 
 @router.post("/applications/{application_id}/upload_file")

--- a/backend/app/routes/institution.py
+++ b/backend/app/routes/institution.py
@@ -6,7 +6,7 @@ from ..database import get_db
 from ..crud import institution as crud
 from ..schemas import InstitutionCreate, InstitutionRead
 
-router = APIRouter(trailing_slash=False, prefix="/institutions", tags=["Institution"])
+router = APIRouter(prefix="/institutions", tags=["Institution"])
 
 @router.post('/', response_model=InstitutionRead)
 def create_institution(data: InstitutionCreate, db: Session = Depends(get_db)):

--- a/backend/app/routes/mobility_entry.py
+++ b/backend/app/routes/mobility_entry.py
@@ -6,7 +6,7 @@ from ..database import get_db
 from ..crud import mobility_entry as crud
 from ..schemas import MobilityEntryCreate, MobilityEntryRead
 
-router = APIRouter(trailing_slash=False, prefix="/mobility_entries", tags=["MobilityEntry"])
+router = APIRouter(prefix="/mobility_entries", tags=["MobilityEntry"])
 
 @router.post('/', response_model=MobilityEntryRead)
 def create_mobility_entry(data: MobilityEntryCreate, db: Session = Depends(get_db)):

--- a/backend/app/routes/review_report.py
+++ b/backend/app/routes/review_report.py
@@ -6,7 +6,7 @@ from ..database import get_db
 from ..crud import review_report as crud
 from ..schemas import ReviewReportCreate, ReviewReportRead
 
-router = APIRouter(trailing_slash=False, prefix="/review_reports", tags=["ReviewReport"])
+router = APIRouter(prefix="/review_reports", tags=["ReviewReport"])
 
 @router.post('/', response_model=ReviewReportRead)
 def create_review_report(data: ReviewReportCreate, db: Session = Depends(get_db)):

--- a/backend/app/routes/security_answer.py
+++ b/backend/app/routes/security_answer.py
@@ -6,7 +6,7 @@ from ..database import get_db
 from ..crud import security_answer as crud
 from ..schemas import SecurityAnswerCreate, SecurityAnswerRead
 
-router = APIRouter(trailing_slash=False, prefix="/security_answers", tags=["SecurityAnswer"])
+router = APIRouter(prefix="/security_answers", tags=["SecurityAnswer"])
 
 @router.post('/', response_model=SecurityAnswerRead)
 def create_security_answer(data: SecurityAnswerCreate, db: Session = Depends(get_db)):

--- a/backend/app/routes/security_euci.py
+++ b/backend/app/routes/security_euci.py
@@ -10,7 +10,7 @@ from ..crud import security_euci as crud
 # correctly named classes instead.
 from ..schemas import SecurityEUCCreate, SecurityEUCIRead
 
-router = APIRouter(trailing_slash=False, prefix="/security_eucis", tags=["SecurityEuci"])
+router = APIRouter(prefix="/security_eucis", tags=["SecurityEuci"])
 
 @router.post('/', response_model=SecurityEUCIRead)
 def create_security_euci(data: SecurityEUCCreate, db: Session = Depends(get_db)):

--- a/backend/app/routes/security_meta.py
+++ b/backend/app/routes/security_meta.py
@@ -6,7 +6,7 @@ from ..database import get_db
 from ..crud import security_meta as crud
 from ..schemas import SecurityMetaCreate, SecurityMetaRead
 
-router = APIRouter(trailing_slash=False, prefix="/security_metas", tags=["SecurityMeta"])
+router = APIRouter(prefix="/security_metas", tags=["SecurityMeta"])
 
 @router.post('/', response_model=SecurityMetaRead)
 def create_security_meta(data: SecurityMetaCreate, db: Session = Depends(get_db)):

--- a/backend/app/routes/security_misuse.py
+++ b/backend/app/routes/security_misuse.py
@@ -6,7 +6,7 @@ from ..database import get_db
 from ..crud import security_misuse as crud
 from ..schemas import SecurityMisuseCreate, SecurityMisuseRead
 
-router = APIRouter(trailing_slash=False, prefix="/security_misuses", tags=["SecurityMisuse"])
+router = APIRouter(prefix="/security_misuses", tags=["SecurityMisuse"])
 
 @router.post('/', response_model=SecurityMisuseRead)
 def create_security_misuse(data: SecurityMisuseCreate, db: Session = Depends(get_db)):

--- a/backend/app/routes/security_other.py
+++ b/backend/app/routes/security_other.py
@@ -6,7 +6,7 @@ from ..database import get_db
 from ..crud import security_other as crud
 from ..schemas import SecurityOtherCreate, SecurityOtherRead
 
-router = APIRouter(trailing_slash=False, prefix="/security_others", tags=["SecurityOther"])
+router = APIRouter(prefix="/security_others", tags=["SecurityOther"])
 
 @router.post('/', response_model=SecurityOtherRead)
 def create_security_other(data: SecurityOtherCreate, db: Session = Depends(get_db)):

--- a/backend/app/routes/suggested_reference.py
+++ b/backend/app/routes/suggested_reference.py
@@ -6,7 +6,7 @@ from ..database import get_db
 from ..crud import suggested_reference as crud
 from ..schemas import SuggestedReferenceCreate, SuggestedReferenceRead
 
-router = APIRouter(trailing_slash=False, prefix="/suggested_references", tags=["SuggestedReference"])
+router = APIRouter(prefix="/suggested_references", tags=["SuggestedReference"])
 
 @router.post('/', response_model=SuggestedReferenceRead)
 def create_suggested_reference(data: SuggestedReferenceCreate, db: Session = Depends(get_db)):

--- a/backend/app/routes/supervisor.py
+++ b/backend/app/routes/supervisor.py
@@ -6,7 +6,7 @@ from ..database import get_db
 from ..crud import supervisor as crud
 from ..schemas import SupervisorCreate, SupervisorRead
 
-router = APIRouter(trailing_slash=False, prefix="/supervisors", tags=["Supervisor"])
+router = APIRouter(prefix="/supervisors", tags=["Supervisor"])
 
 @router.post('/', response_model=SupervisorRead)
 def create_supervisor(data: SupervisorCreate, db: Session = Depends(get_db)):

--- a/backend/app/routes/user.py
+++ b/backend/app/routes/user.py
@@ -8,7 +8,7 @@ from ..schemas import UserCreate, UserRead
 from ..core.security import role_required
 from ..core.enums import UserRole
 
-router = APIRouter(trailing_slash=False, prefix="/users", tags=["User"])
+router = APIRouter(prefix="/users", tags=["User"])
 
 @router.post('/', response_model=UserRead)
 def create_user(data: UserCreate, db: Session = Depends(get_db)):


### PR DESCRIPTION
## Summary
- remove deprecated `trailing_slash` parameter from all routers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6851e3db324c832cb68b9d7f34a510c8