### PR TITLE
Add reviewer role check to review report endpoints

### DIFF
--- a/backend/app/routes/review_report.py
+++ b/backend/app/routes/review_report.py
@@ -5,14 +5,18 @@ import uuid
 from ..database import get_db
 from ..crud import review_report as crud
 from ..schemas import ReviewReportCreate, ReviewReportRead
+from ..core.security import role_required
+from ..core.enums import UserRole
 
 router = APIRouter(prefix="/review_reports", tags=["ReviewReport"])
 
 @router.post('/', response_model=ReviewReportRead)
+@role_required(UserRole.reviewer)
 def create_review_report(data: ReviewReportCreate, db: Session = Depends(get_db)):
     return crud.create(db, data.dict())
 
 @router.get('/{obj_id}', response_model=ReviewReportRead)
+@role_required(UserRole.reviewer)
 def read_review_report(obj_id: uuid.UUID, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
@@ -20,10 +24,12 @@ def read_review_report(obj_id: uuid.UUID, db: Session = Depends(get_db)):
     return obj
 
 @router.get('/', response_model=list[ReviewReportRead])
+@role_required(UserRole.reviewer)
 def read_review_reports(db: Session = Depends(get_db)):
     return list(crud.get_all(db))
 
 @router.put('/{obj_id}', response_model=ReviewReportRead)
+@role_required(UserRole.reviewer)
 def update_review_report(obj_id: uuid.UUID, data: ReviewReportCreate, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
@@ -31,6 +37,7 @@ def update_review_report(obj_id: uuid.UUID, data: ReviewReportCreate, db: Sessio
     return crud.update(db, obj, data.dict())
 
 @router.delete('/{obj_id}')
+@role_required(UserRole.reviewer)
 def delete_review_report(obj_id: uuid.UUID, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)
     if not obj:


### PR DESCRIPTION
## Summary
- protect all review report routes with `@role_required(UserRole.reviewer)`
- import `role_required` and `UserRole`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6853e65b1ef8832c82cebcff9705f49d