### PR TITLE
Add user update schema and hashing logic

### DIFF
--- a/backend/app/crud/user.py
+++ b/backend/app/crud/user.py
@@ -31,6 +31,10 @@ def get_all(db: Session, include_deleted: bool = False):
 
 
 def update(db: Session, obj: User, data: dict) -> User:
+    if "password" in data:
+        password = data.pop("password")
+        if password is not None:
+            data["password_hash"] = hash_password(password)
     return _update(db, obj, data)
 
 

--- a/backend/app/routes/user.py
+++ b/backend/app/routes/user.py
@@ -4,7 +4,7 @@ import uuid
 
 from ..database import get_db
 from ..crud import user as crud
-from ..schemas import UserCreate, UserRead
+from ..schemas import UserCreate, UserRead, UserUpdate
 from ..core.security import role_required
 from ..core.enums import UserRole
 
@@ -31,7 +31,7 @@ def read_users(db: Session = Depends(get_db)):
 
 @router.put('/{obj_id}', response_model=UserRead)
 @role_required(UserRole.super_admin)
-def update_user(obj_id: uuid.UUID, data: UserCreate, db: Session = Depends(get_db)):
+def update_user(obj_id: uuid.UUID, data: UserUpdate, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="User not found")

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -25,7 +25,7 @@ from .security_misuse import SecurityMisuseBase, SecurityMisuseCreate, SecurityM
 from .security_other import SecurityOtherBase, SecurityOtherCreate, SecurityOtherRead
 from .suggested_reference import SuggestedReferenceBase, SuggestedReferenceCreate, SuggestedReferenceRead
 from .supervisor import SupervisorBase, SupervisorCreate, SupervisorRead
-from .user import UserBase, UserCreate, UserRead
+from .user import UserBase, UserCreate, UserRead, UserUpdate
 from .auth import Token, Login
 
 __all__ = [
@@ -112,6 +112,7 @@ __all__ = [
     "SupervisorRead",
     "UserBase",
     "UserCreate",
+    "UserUpdate",
     "UserRead",
     "Token",
     "Login"

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -11,6 +11,10 @@ class UserCreate(UserBase):
     password: str
 
 
+class UserUpdate(UserBase):
+    password: Optional[str] = None
+
+
 class UserRead(UserBase):
     id: uuid.UUID
     created_at: Optional[datetime]


### PR DESCRIPTION
## Summary
- introduce `UserUpdate` schema with optional `password`
- export new schema through `schemas.__init__`
- accept `UserUpdate` in user update endpoint
- hash password when updating users

## Testing
- `pip install -r requirements.txt` *(fails: Could not fetch packages)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6853ebaee07c832cb022bedc754c90b0