### PR TITLE
Add CallDetailPage and routing

### DIFF
--- a/frontend/src/pages/calls/CallDetailPage.tsx
+++ b/frontend/src/pages/calls/CallDetailPage.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { useToast } from "../../context/ToastProvider";
+import { getCall } from "../../lib/api/calls";
+import { Call } from "../../types/global";
+import { Button } from "../../components/ui/Button";
+
+export default function CallDetailPage() {
+  const { callId } = useParams<{ callId: string }>();
+  const { show } = useToast();
+  const [call, setCall] = useState<Call | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!callId) return;
+    setLoading(true);
+    setError(null);
+    getCall(callId)
+      .then((data) => {
+        setCall(data);
+        show("Call loaded");
+      })
+      .catch((err) => {
+        setError(err.message);
+        show("Failed to load call");
+      })
+      .finally(() => setLoading(false));
+  }, [callId, show]);
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div className="text-red-500">Error: {error}</div>;
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-bold">{call?.title}</h1>
+      <p>{call?.description}</p>
+      {callId && (
+        <Link to={`/calls/${callId}/apply`}>
+          <Button>Apply</Button>
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -15,6 +15,7 @@ import DashboardPage from "./DashboardPage";
 import CallManagementPage from "./CallManagementPage";
 import CallApplicationsPage from "./CallApplicationsPage";
 import CallPreviewPage from "./CallPreviewPage";
+import CallDetailPage from "../pages/calls/CallDetailPage";
 import ReviewPage from "./ReviewPage";
 import NotFoundPage from "./NotFoundPage";
 
@@ -32,6 +33,7 @@ export default function AppRoutes() {
           <Route path="calls/manage" element={<CallManagementPage />} />
           <Route path="calls/:callId/applications" element={<CallApplicationsPage />} />
         </Route>
+        <Route path="calls/:callId" element={<CallDetailPage />} />
         <Route path="calls/:callId/preview" element={<CallPreviewPage />} />
         <Route element={<ProtectedRoute />}>
           <Route path="calls/:callId/apply" element={<ApplicationLayout />}>


### PR DESCRIPTION
## Summary
- show call detail and apply button
- load call data using `getCall`
- route `/calls/:callId` to new page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6853f8d1ba2c832caaf30a83b1ff8184