### PR TITLE
Add vertical sidebar navigation for application steps

### DIFF
--- a/frontend/src/routes/calls/apply/ApplicationLayout.tsx
+++ b/frontend/src/routes/calls/apply/ApplicationLayout.tsx
@@ -1,5 +1,5 @@
-import { Outlet, useParams } from "react-router-dom";
-import Stepper, { Step } from "../../../components/common/Stepper";
+import { NavLink, Outlet, useLocation, useParams } from "react-router-dom";
+import { Step } from "../../../components/common/Stepper";
 import { ApplicationProvider } from "../../../context/ApplicationProvider";
 
 
@@ -12,14 +12,38 @@ const steps: Step[] = [
 
 export default function ApplicationLayout() {
   const { callId } = useParams<{ callId: string }>();
+  const location = useLocation();
 
   if (!callId) return null;
 
+  const activeIndex = steps.findIndex((s) =>
+    location.pathname.includes(s.path)
+  );
+
   return (
     <ApplicationProvider callId={callId}>
-      <div className="p-4">
-        <Stepper steps={steps} />
-        <Outlet />
+      <div className="p-4 flex space-x-4">
+        <nav className="w-48 space-y-2" aria-label="Progress">
+          {steps.map((step, index) => (
+            <NavLink
+              key={step.path}
+              to={step.path}
+              className={({ isActive }) =>
+                [
+                  "block px-4 py-2 rounded-md",
+                  index === activeIndex
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-muted text-muted-foreground",
+                ].join(" ")
+              }
+            >
+              {step.name}
+            </NavLink>
+          ))}
+        </nav>
+        <div className="flex-1">
+          <Outlet />
+        </div>
       </div>
     </ApplicationProvider>
   );


### PR DESCRIPTION
## Summary
- replace horizontal Stepper with a vertical sidebar in ApplicationLayout

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client' – dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6853f8e3b27c832ca6b1331a8183bd82