### PR TITLE
Add API helpers and refactor pages

### DIFF
--- a/frontend/src/context/ApplicationProvider.tsx
+++ b/frontend/src/context/ApplicationProvider.tsx
@@ -1,5 +1,11 @@
 import { createContext, useContext, useEffect, useState, ReactNode } from "react";
-import { apiFetch, getApplicationAttachments } from "../lib/api";
+import {
+  createApplication as apiCreateApplication,
+  uploadAttachment as apiUploadAttachment,
+  deleteAttachment as apiDeleteAttachment,
+  updateApplication,
+  getApplicationAttachments,
+} from "../lib/api/applications";
 import { getCall } from "../lib/api/calls";
 import { Call } from "../types";
 import { Attachment } from "../types/application";
@@ -64,39 +70,26 @@ export function ApplicationProvider({
 
   const createApplication = async () => {
     if (applicationId) return;
-    const data = await apiFetch(`/applications/`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ call_id: callId }),
-    });
+    const data = await apiCreateApplication(callId);
     setApplicationId(data.id as string);
   };
 
   const uploadAttachment = async (file: File) => {
     if (!applicationId) return;
-    const formData = new FormData();
-    formData.append("upload", file);
-    const data = await apiFetch(
-      `/applications/${applicationId}/upload_file`,
-      {
-        method: "POST",
-        body: formData,
-      }
-    );
+    const data = await apiUploadAttachment(applicationId, file);
     setAttachments((prev) => [...prev, data]);
   };
 
   const deleteAttachment = async (id: string) => {
-    await apiFetch(`/attachments/${id}`, { method: "DELETE" });
+    await apiDeleteAttachment(id);
     setAttachments((prev) => prev.filter((a) => a.id !== id));
   };
 
   const submitApplication = async () => {
     if (!applicationId) return;
-    await apiFetch(`/applications/${applicationId}`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ call_id: callId, status: "SUBMITTED" }),
+    await updateApplication(applicationId, {
+      call_id: callId,
+      status: "SUBMITTED",
     });
   };
 

--- a/frontend/src/context/AuthProvider.tsx
+++ b/frontend/src/context/AuthProvider.tsx
@@ -1,5 +1,5 @@
 import { createContext, ReactNode, useContext, useEffect, useState } from "react";
-import { apiFetch } from "../lib/api";
+import { login as apiLogin, register as apiRegister } from "../lib/api/auth";
 
 interface AuthState {
   token: string | null;
@@ -51,19 +51,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [state.token]);
 
   const login = async (email: string, password: string) => {
-    const data = await apiFetch("/auth/login", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email, password }),
-    });
+    const data = await apiLogin({ email, password });
     setState({ token: data.access_token, user: decodeToken(data.access_token) });
   };
 
   const register = async (email: string, password: string) => {
-    await apiFetch("/auth/register", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email, password, first_name: "", last_name: "" }),
+    await apiRegister({
+      email,
+      password,
+      first_name: "",
+      last_name: "",
     });
     await login(email, password);
   };

--- a/frontend/src/lib/api/applications.ts
+++ b/frontend/src/lib/api/applications.ts
@@ -4,6 +4,7 @@ import type {
   CreateApplicationResponse,
   UploadAttachmentResponse,
 } from "../../types/applications.types";
+import type { Attachment } from "../../types/reviews.types";
 
 export function createApplication(callId: string) {
   const body: CreateApplicationRequest = { call_id: callId };
@@ -21,4 +22,32 @@ export function uploadAttachment(applicationId: string, file: File) {
     method: "POST",
     body: formData,
   }) as Promise<UploadAttachmentResponse>;
+}
+
+export function getApplications() {
+  return apiFetch(`/applications`) as Promise<any[]>;
+}
+
+export function getApplication(id: string) {
+  return apiFetch(`/applications/${id}`) as Promise<any>;
+}
+
+export function updateApplication(id: string, data: Record<string, unknown>) {
+  return apiFetch(`/applications/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export function deleteApplication(id: string) {
+  return apiFetch(`/applications/${id}`, { method: "DELETE" });
+}
+
+export function getApplicationAttachments(id: string) {
+  return apiFetch(`/attachments/application/${id}`) as Promise<Attachment[]>;
+}
+
+export function deleteAttachment(id: string) {
+  return apiFetch(`/attachments/${id}`, { method: "DELETE" });
 }

--- a/frontend/src/lib/api/calls.ts
+++ b/frontend/src/lib/api/calls.ts
@@ -8,3 +8,23 @@ export function getCalls() {
 export function getCall(id: string) {
   return apiFetch(`/calls/${id}`) as Promise<GetCallResponse>;
 }
+
+export function createCall(data: { title: string; description?: string }) {
+  return apiFetch(`/calls`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export function updateCall(id: string, data: { title: string; description?: string }) {
+  return apiFetch(`/calls/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export function deleteCall(id: string) {
+  return apiFetch(`/calls/${id}`, { method: "DELETE" });
+}

--- a/frontend/src/lib/api/reviews.ts
+++ b/frontend/src/lib/api/reviews.ts
@@ -2,10 +2,21 @@ import { apiFetch } from "../api";
 import type { ReviewReport, SubmitReviewResponse } from "../../types/reviews.types";
 
 export function submitReview(data: ReviewReport) {
-
   return apiFetch("/review_reports", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
   }) as Promise<SubmitReviewResponse>;
+}
+
+export function getReviewReport(id: string) {
+  return apiFetch(`/review_reports/${id}`) as Promise<ReviewReport>;
+}
+
+export function createReviewReport(data: ReviewReport) {
+  return apiFetch(`/review_reports`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
 }

--- a/frontend/src/routes/CallApplicationsPage.tsx
+++ b/frontend/src/routes/CallApplicationsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useToast } from "../context/ToastProvider";
-import { apiFetch } from "../lib/api";
+import { getApplications } from "../lib/api/applications";
 
 interface Application {
   id: string;
@@ -15,7 +15,7 @@ export default function CallApplicationsPage() {
   useEffect(() => {
     setLoading(true);
     setError(null);
-    apiFetch("/applications")
+    getApplications()
       .then((data) => {
         setApps(data);
         show("Applications loaded");

--- a/frontend/src/routes/CallManagementPage.tsx
+++ b/frontend/src/routes/CallManagementPage.tsx
@@ -2,8 +2,7 @@ import { FormEvent, useEffect, useState } from "react";
 import  { Button } from "../components/ui/Button";
 import { Input } from "../components/ui/Input";
 import Table from "../components/ui/Table";
-import { apiFetch } from "../lib/api";
-import { getCalls } from "../lib/api/calls";
+import { getCalls, createCall, updateCall, deleteCall } from "../lib/api/calls";
 import { Call } from "../types/global";
 
 export default function CallManagementPage() {
@@ -29,19 +28,18 @@ export default function CallManagementPage() {
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
-    const body = JSON.stringify({ title, description });
-    const headers = { "Content-Type": "application/json" };
+    const data = { title, description };
     if (editing) {
-      await apiFetch(`/calls/${editing.id}`, { method: "PUT", headers, body });
+      await updateCall(editing.id, data);
     } else {
-      await apiFetch("/calls", { method: "POST", headers, body });
+      await createCall(data);
     }
     reset();
     load();
   }
 
   async function remove(id: string) {
-    await apiFetch(`/calls/${id}`, { method: "DELETE" });
+    await deleteCall(id);
     load();
   }
 

--- a/frontend/src/routes/DashboardPage.tsx
+++ b/frontend/src/routes/DashboardPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import Card from "../components/ui/Card";
-import { apiFetch } from "../lib/api";
+import { getApplications } from "../lib/api/applications";
 import { getCalls } from "../lib/api/calls";
 
 export default function DashboardPage() {
@@ -10,7 +10,7 @@ export default function DashboardPage() {
     async function load() {
       try {
         const calls = await getCalls();
-        const apps = await apiFetch("/applications");
+        const apps = await getApplications();
         setStats({ calls: calls.length, applications: apps.length });
       } catch {
         // ignore errors for demo

--- a/frontend/src/routes/ReviewPage.tsx
+++ b/frontend/src/routes/ReviewPage.tsx
@@ -5,11 +5,8 @@ import { Input } from "../components/ui/Input";
 import { Button } from "../components/ui/Button";
 import { useToast } from "../context/ToastProvider";
 import type { Attachment, ReviewReport, Review } from "../types/reviews.types";
-import {
-  getReviewReport,
-  getApplicationAttachments,
-  createReviewReport,
-} from "../lib/api";
+import { getReviewReport, createReviewReport } from "../lib/api/reviews";
+import { getApplicationAttachments } from "../lib/api/applications";
 
 
 export default function ReviewPage() {


### PR DESCRIPTION
## Summary
- expose additional API helper functions
- use helpers across context providers and pages
- support call management with create/update/delete helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm test --silent` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_6853f91470f4832c966710a2664a9c81