### PR TITLE
Add Radix confirm modal

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.12.1"
+    "react-router-dom": "^6.12.1",
+    "@radix-ui/react-dialog": "^1.0.5"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/frontend/src/components/DocumentList.tsx
+++ b/frontend/src/components/DocumentList.tsx
@@ -1,5 +1,7 @@
 
+import { useState } from "react";
 import { Attachment } from "../types/application";
+import ConfirmModal from "./ui/ConfirmModal";
 
 export default function DocumentList({
   documents,
@@ -8,6 +10,7 @@ export default function DocumentList({
   documents: Attachment[];
   onDelete?: (id: string) => void;
 }) {
+  const [confirmId, setConfirmId] = useState<string | null>(null);
   if (documents.length === 0) {
     return <p>No documents uploaded.</p>;
   }
@@ -18,12 +21,21 @@ export default function DocumentList({
         <li key={doc.id} className="flex justify-between border p-2 rounded">
           <span>{doc.doc_name}</span>
           {onDelete && (
-            <button
-              className="text-red-500"
-              onClick={() => onDelete(doc.id)}
-            >
-              Delete
-            </button>
+            <>
+              <button
+                className="text-red-500"
+                onClick={() => setConfirmId(doc.id)}
+              >
+                Delete
+              </button>
+              <ConfirmModal
+                open={confirmId === doc.id}
+                onOpenChange={() => setConfirmId(null)}
+                title="Delete document?"
+                description="This action cannot be undone."
+                onConfirm={() => onDelete(doc.id)}
+              />
+            </>
           )}
         </li>
       ))}

--- a/frontend/src/components/ui/ConfirmModal.tsx
+++ b/frontend/src/components/ui/ConfirmModal.tsx
@@ -1,0 +1,52 @@
+import * as Dialog from "@radix-ui/react-dialog";
+import { ReactNode } from "react";
+import { Button } from "./Button";
+
+interface ConfirmModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title?: string;
+  description?: string;
+  onConfirm: () => void;
+  confirmText?: string;
+  cancelText?: string;
+}
+
+export default function ConfirmModal({
+  open,
+  onOpenChange,
+  title,
+  description,
+  onConfirm,
+  confirmText = "Confirm",
+  cancelText = "Cancel",
+}: ConfirmModalProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50" />
+        <Dialog.Content className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white p-4 rounded shadow space-y-4 max-w-sm w-full">
+          {title && (
+            <Dialog.Title className="text-lg font-semibold">{title}</Dialog.Title>
+          )}
+          {description && (
+            <Dialog.Description>{description}</Dialog.Description>
+          )}
+          <div className="flex justify-end gap-2">
+            <Dialog.Close asChild>
+              <Button variant="outline">{cancelText}</Button>
+            </Dialog.Close>
+            <Button
+              onClick={() => {
+                onConfirm();
+                onOpenChange(false);
+              }}
+            >
+              {confirmText}
+            </Button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/frontend/src/routes/calls/apply/Step4_Submit.tsx
+++ b/frontend/src/routes/calls/apply/Step4_Submit.tsx
@@ -1,6 +1,7 @@
 
 import { useState } from "react";
 import { Button } from "../../../components/ui/Button";
+import ConfirmModal from "../../../components/ui/ConfirmModal";
 import { useToast } from "../../../context/ToastProvider";
 import { useApplication } from "../../../context/ApplicationProvider";
 
@@ -8,6 +9,7 @@ export default function Step4_Submit() {
   const { submitApplication } = useApplication();
   const { show } = useToast();
   const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const handleSubmit = async () => {
@@ -27,9 +29,16 @@ export default function Step4_Submit() {
   return (
     <div>
       <p>Ready to submit your application.</p>
-      <Button onClick={handleSubmit} disabled={loading}>
+      <Button onClick={() => setOpen(true)} disabled={loading}>
         {loading ? "Loading..." : "Submit"}
       </Button>
+      <ConfirmModal
+        open={open}
+        onOpenChange={setOpen}
+        title="Submit application?"
+        description="You won't be able to edit after submitting."
+        onConfirm={handleSubmit}
+      />
       {error && <div className="text-red-500">Error: {error}</div>}
     </div>
   );


### PR DESCRIPTION
## Summary
- add `@radix-ui/react-dialog` dependency
- create `ConfirmModal` component using Radix
- use `ConfirmModal` for deleting documents
- confirm before submitting an application

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6853f917c6e0832ca44fb5e71d9b848e