### PR TITLE
Add /calls route

### DIFF
--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -29,6 +29,7 @@ export default function AppRoutes() {
       <Route path="/review/:reviewId" element={<ReviewPage />} />
       <Route path="/" element={<PageContainer />}>
         <Route index element={<CallsPage />} />
+        <Route path="calls" element={<CallsPage />} />
         <Route path="about" element={<AboutPage />} />
         <Route element={<PrivateRoute roles={[UserRole.admin, UserRole.super_admin]} />}>
           <Route path="dashboard" element={<DashboardPage />} />


### PR DESCRIPTION
## Summary
- show `CallsPage` at `/calls`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_685401177a04832cb2953b6b854d498a