### PR TITLE
Add reviewer dashboard

### DIFF
--- a/frontend/src/lib/api/reviews.ts
+++ b/frontend/src/lib/api/reviews.ts
@@ -13,6 +13,10 @@ export function getReviewReport(id: string) {
   return apiFetch(`/review_reports/${id}`) as Promise<ReviewReport>;
 }
 
+export function getReviewReports() {
+  return apiFetch(`/review_reports`) as Promise<ReviewReport[]>;
+}
+
 export function createReviewReport(data: ReviewReport) {
   return apiFetch(`/review_reports`, {
     method: "POST",

--- a/frontend/src/routes/ReviewerPage.tsx
+++ b/frontend/src/routes/ReviewerPage.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { useToast } from "../context/ToastProvider";
+import { getReviewReports } from "../lib/api/reviews";
+import type { ReviewReport } from "../types/reviews.types";
+
+export default function ReviewerPage() {
+  const { show } = useToast();
+  const [reviews, setReviews] = useState<ReviewReport[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    getReviewReports()
+      .then((data) => {
+        setReviews(data);
+        show("Reviews loaded");
+      })
+      .catch((err) => {
+        setError(err.message);
+        show("Failed to load reviews");
+      })
+      .finally(() => setLoading(false));
+  }, [show]);
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div className="text-red-500">Error: {error}</div>;
+
+  return (
+    <div>
+      <h1>My Reviews</h1>
+      <ul className="list-disc pl-5 space-y-2">
+        {reviews.map((r) => (
+          <li key={r.id} className="flex items-center space-x-4">
+            <span>{r.project_title || r.id}</span>
+            <Link to={`/review/${r.id}`} className="text-blue-600 underline">
+              Review
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -20,6 +20,7 @@ import CallDetailPage from "../pages/calls/CallDetailPage";
 import ReviewPage from "./ReviewPage";
 import NotFoundPage from "./NotFoundPage";
 import MyApplicationsPage from "../pages/MyApplicationsPage";
+import ReviewerPage from "./ReviewerPage";
 
 export default function AppRoutes() {
   return (
@@ -39,6 +40,9 @@ export default function AppRoutes() {
         <Route path="calls/:callId/preview" element={<CallPreviewPage />} />
         <Route element={<ProtectedRoute roles={[UserRole.applicant]} />}>
           <Route path="my-applications" element={<MyApplicationsPage />} />
+        </Route>
+        <Route element={<ProtectedRoute roles={[UserRole.reviewer]} />}>
+          <Route path="reviewer" element={<ReviewerPage />} />
         </Route>
         <Route element={<ProtectedRoute />}>
           <Route path="calls/:callId/apply" element={<ApplicationLayout />}>


### PR DESCRIPTION
## Summary
- implement `ReviewerPage` listing assigned reviews
- expose a `getReviewReports` helper
- add the reviewer dashboard route

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6854011a1958832c92a709fdd4f38e36