### PR TITLE
Add applications link in CallManagementPage

### DIFF
--- a/frontend/src/routes/CallManagementPage.tsx
+++ b/frontend/src/routes/CallManagementPage.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useEffect, useState } from "react";
-import  { Button } from "../components/ui/Button";
+import { Link } from "react-router-dom";
+import { Button } from "../components/ui/Button";
 import { Input } from "../components/ui/Input";
 import Table from "../components/ui/Table";
 import { getCalls, createCall, updateCall, deleteCall } from "../lib/api/calls";
@@ -68,7 +69,8 @@ export default function CallManagementPage() {
         <thead>
           <tr className="bg-gray-100">
             <th>Title</th>
-            <th></th>
+            <th>Actions</th>
+            <th>Applications</th>
           </tr>
         </thead>
         <tbody>
@@ -82,6 +84,11 @@ export default function CallManagementPage() {
                 <Button type="button" onClick={() => remove(c.id)}>
                   Delete
                 </Button>
+              </td>
+              <td>
+                <Link to={`/calls/${c.id}/applications`}>
+                  <Button variant="link">Applications</Button>
+                </Link>
               </td>
             </tr>
           ))}


### PR DESCRIPTION
## Summary
- add Applications link to Call Management table
- verify `calls/:callId/applications` remains protected

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685401227250832c876894177f2944a4