### PR TITLE
Handle API failures with toasts

### DIFF
--- a/frontend/src/routes/calls/apply/Step4_Submit.tsx
+++ b/frontend/src/routes/calls/apply/Step4_Submit.tsx
@@ -15,15 +15,13 @@ export default function Step4_Submit() {
   const handleSubmit = async () => {
     setLoading(true);
     setError(null);
-    try {
-      await submitApplication();
+    const success = await submitApplication();
+    if (success) {
       show("Application submitted");
-    } catch (err) {
-      setError((err as Error).message);
-      show("Submission failed");
-    } finally {
-      setLoading(false);
+    } else {
+      setError("Submission failed");
     }
+    setLoading(false);
   };
 
   return (


### PR DESCRIPTION
## Summary
- show toast messages for errors in `ApplicationProvider`
- update application submission step to check success

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68540129200c832c91c4407f8ea927d6