### PR TITLE
Add loading/error states to dashboard

### DIFF
--- a/frontend/src/routes/DashboardPage.tsx
+++ b/frontend/src/routes/DashboardPage.tsx
@@ -5,19 +5,28 @@ import { getCalls } from "../lib/api/calls";
 
 export default function DashboardPage() {
   const [stats, setStats] = useState({ calls: 0, applications: 0 });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     async function load() {
+      setLoading(true);
+      setError(null);
       try {
         const calls = await getCalls();
         const apps = await getApplications();
         setStats({ calls: calls.length, applications: apps.length });
-      } catch {
-        // ignore errors for demo
+      } catch (err) {
+        setError((err as Error).message);
+      } finally {
+        setLoading(false);
       }
     }
     load();
   }, []);
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div className="text-red-500">Error: {error}</div>;
 
   return (
     <div className="space-y-4">


### PR DESCRIPTION
## Summary
- show loading and error messages on the dashboard
- update `load()` function to set these states

## Testing
- `npm test` *(fails: registry access blocked)*
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68540137071c832cafee23d40359dec8