### PR TITLE
Fix API import paths

### DIFF
--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,4 +1,4 @@
-import { apiFetch } from "../api";
+import { apiFetch } from "../lib/api";
 import type { LoginData, RegisterData } from "../../types/auth.types";
 
 export function login(data: LoginData) {

--- a/frontend/src/api/calls.ts
+++ b/frontend/src/api/calls.ts
@@ -1,4 +1,4 @@
-import { apiFetch } from "../api";
+import { apiFetch } from "../lib/api";
 import type { GetCallsResponse, GetCallResponse } from "../../types/calls.types";
 
 export function getCalls() {

--- a/frontend/src/api/reviews.ts
+++ b/frontend/src/api/reviews.ts
@@ -1,4 +1,4 @@
-import { apiFetch } from "../api";
+import { apiFetch } from "../lib/api";
 import type { ReviewReport, SubmitReviewResponse } from "../../types/reviews.types";
 
 export function submitReview(data: ReviewReport) {


### PR DESCRIPTION
## Summary
- update src api modules to import `apiFetch` from `../lib/api`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685440ed102c832cba2a89efda5209d3