### PR TITLE
Update sidebar display logic

### DIFF
--- a/frontend/src/components/layout/PageContainer.tsx
+++ b/frontend/src/components/layout/PageContainer.tsx
@@ -1,14 +1,17 @@
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 import Navbar from "./Navbar";
 import Sidebar from "./Sidebar";
 
 export default function PageContainer() {
+  const { pathname } = useLocation();
+  const showSidebar = pathname.includes("/apply");
+
   return (
     <div className="min-h-screen flex flex-col">
       <Navbar />
       <div className="flex flex-1">
-        <Sidebar />
-        <main className="flex-1 p-4">
+        {showSidebar && <Sidebar />}
+        <main className={`${showSidebar ? "flex-1" : "w-full"} p-4`}>
           <Outlet />
         </main>
       </div>

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -1,3 +1,8 @@
 export default function AboutPage() {
-  return <div>About this platform.</div>;
+  return (
+    <div>
+      METU Project Call Platform enables users to create, manage and apply to
+      research project calls with ease.
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- adjust PageContainer layout to only show sidebar on `/apply` routes
- improve description on About page

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68544971c590832c80af0bd992d3c8bb