### PR TITLE
Add user application route and API helper

### DIFF
--- a/backend/app/routes/application.py
+++ b/backend/app/routes/application.py
@@ -6,6 +6,7 @@ from ..database import get_db
 from ..crud import application as crud
 from ..schemas import ApplicationCreate, ApplicationRead
 from ..core.security import get_current_user
+from ..models import User
 
 router = APIRouter(prefix="/applications", tags=["Application"])
 
@@ -34,6 +35,14 @@ def read_application(obj_id: uuid.UUID, db: Session = Depends(get_db)):
 @router.get('/', response_model=list[ApplicationRead])
 def read_applications(db: Session = Depends(get_db)):
     return list(crud.get_all(db))
+
+
+@router.get('/me', response_model=list[ApplicationRead])
+def read_my_applications(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user)
+):
+    return list(crud.get_applications_by_user_id(db, current_user.id))
 
 @router.put('/{obj_id}', response_model=ApplicationRead)
 def update_application(

--- a/frontend/src/api/applications.ts
+++ b/frontend/src/api/applications.ts
@@ -28,6 +28,10 @@ export function getApplications() {
   return apiFetch(`/applications`) as Promise<any[]>;
 }
 
+export function getMyApplications() {
+  return apiFetch(`/applications/me`) as Promise<any[]>;
+}
+
 export function updateApplication(id: string, data: Record<string, unknown>) {
   return apiFetch(`/applications/${id}`, {
     method: "PUT",

--- a/frontend/src/pages/MyApplicationsPage.tsx
+++ b/frontend/src/pages/MyApplicationsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { apiFetch } from "../lib/api";
+import { getMyApplications } from "../api/applications";
 import { useToast } from "../context/ToastProvider";
 
 interface Application {
@@ -17,7 +17,7 @@ export default function MyApplicationsPage() {
   useEffect(() => {
     setLoading(true);
     setError(null);
-    apiFetch("/applications/me")
+    getMyApplications()
       .then((data) => {
         setApplications(data);
         show("Applications loaded");


### PR DESCRIPTION
## Summary
- expose `/applications/me` to fetch applications for the current user
- wrap new backend route with `getMyApplications` helper
- use the helper in `MyApplicationsPage`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68544973ed54832ca6c65320fca2f847