### PR TITLE
Fix JWT decode in AuthProvider

### DIFF
--- a/frontend/src/context/AuthProvider.tsx
+++ b/frontend/src/context/AuthProvider.tsx
@@ -24,9 +24,15 @@ const AuthContext = createContext<AuthContextValue>({
   userId: null,
 });
 
+function decodeBase64Url(input: string) {
+  const base64 = input.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
+  return atob(padded);
+}
+
 function decodeToken(token: string): { id: string; role: string } | null {
   try {
-    const payload = JSON.parse(atob(token.split(".")[1]));
+    const payload = JSON.parse(decodeBase64Url(token.split(".")[1]));
     return { id: payload.sub, role: payload.role };
   } catch {
     return null;


### PR DESCRIPTION
## Summary
- handle base64url JWT payloads in AuthProvider
- parse the JWT payload with this helper

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6854497569ac832c8964bf27832b43a7