### PR TITLE
Add empty review message

### DIFF
--- a/frontend/src/pages/ReviewerPage.tsx
+++ b/frontend/src/pages/ReviewerPage.tsx
@@ -27,6 +27,9 @@ export default function ReviewerPage() {
 
   if (loading) return <div>Loading...</div>;
   if (error) return <div className="text-red-500">Error: {error}</div>;
+  if (reviews.length === 0) {
+    return <div>No reviews assigned at the moment.</div>;
+  }
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- show message when reviewers have no assignments

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685449783334832c8d7e0a6a0e83fd17