### PR TITLE
Improve login error handling

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -10,7 +10,14 @@ export async function apiFetch(path: string, options: RequestInit = {}) {
   }
   const res = await fetch(`${API_BASE}${path}`, { ...options, headers });
   if (!res.ok) {
-    const message = await res.text();
+    const text = await res.text();
+    let message: string | undefined = undefined;
+    try {
+      const data = JSON.parse(text);
+      message = data.detail || data.message || text;
+    } catch {
+      message = text;
+    }
     throw new Error(message || res.statusText);
   }
   if (res.status === 204) return null;

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -17,16 +17,23 @@ export default function LoginPage() {
   const [error, setError] = useState<string | null>(null);
 
   const handleLogin = async () => {
+    if (!email || !password) {
+      const msg = "Email and password are required";
+      setError(msg);
+      show(msg);
+      return;
+    }
+
     setLoading(true);
     setError(null);
     try {
       await login(email, password);
       show("Logged in successfully");
-      navigate("/"); // Giriş sonrası yönlendirme
+      navigate("/");
     } catch (err) {
       const msg = (err as Error).message || "Login failed";
       setError(msg);
-      show("Login failed");
+      show(msg);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- parse JSON error responses in `apiFetch`
- show returned login error message in toast and on the page
- validate that email and password are provided before login

## Testing
- `npm install` *(fails: blocked network access)*

------
https://chatgpt.com/codex/tasks/task_e_6854497f8384832c924cefd07702ea27