### PR TITLE
Update navbar admin role check

### DIFF
--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -22,7 +22,7 @@ export default function Navbar() {
           {token && role === "applicant" && (
             <Link to="/my-applications" className="hover:underline">My Applications</Link>
           )}
-          {token && role === "admin" && (
+          {token && (role === "admin" || role === "super_admin") && (
             <Link to="/calls/manage" className="hover:underline">Manage Calls</Link>
           )}
           {token && role === "reviewer" && (


### PR DESCRIPTION
## Summary
- update admin link visibility to include super admins

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68544d09b37c832c86d5c1cc0c9b65f1