### PR TITLE
Replace anchor tags with Link on auth pages

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 import { Input } from "../components/ui/Input";
 import { Button } from "../components/ui/Button";
 import Navbar from "../components/layout/Navbar";
@@ -85,9 +85,9 @@ export default function LoginPage() {
             </Button>
 
             <p className="text-center text-sm text-gray-600">
-              <a href="/password-reset" className="text-blue-600 hover:underline">
+              <Link to="/password-reset" className="text-blue-600 hover:underline">
                 Forgot your password?
-              </a>
+              </Link>
             </p>
           </form>
         </div>

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 import { Input } from "../components/ui/Input";
 import { Button } from "../components/ui/Button";
 import Navbar from "../components/layout/Navbar";
@@ -64,7 +64,7 @@ export default function RegisterPage() {
 
             <p className="text-center text-sm text-gray-600">
               Already have an account?{" "}
-              <a href="/login" className="text-blue-600 hover:underline">Log in</a>
+              <Link to="/login" className="text-blue-600 hover:underline">Log in</Link>
             </p>
           </form>
         </div>


### PR DESCRIPTION
## Summary
- use `<Link>` instead of `<a>` in login and register pages
- add required imports from `react-router-dom`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68544d242370832cb897681a45bcbf2a