### PR TITLE
Add admin dashboard link in navbar

### DIFF
--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -23,7 +23,10 @@ export default function Navbar() {
             <Link to="/my-applications" className="hover:underline">My Applications</Link>
           )}
           {token && (role === "admin" || role === "super_admin") && (
-            <Link to="/calls/manage" className="hover:underline">Manage Calls</Link>
+            <>
+              <Link to="/dashboard" className="hover:underline">Dashboard</Link>
+              <Link to="/calls/manage" className="hover:underline">Manage Calls</Link>
+            </>
           )}
           {token && role === "reviewer" && (
             <Link to="/reviewer" className="hover:underline">My Reviews</Link>


### PR DESCRIPTION
## Summary
- show Dashboard and Manage Calls for admin and super_admin roles in the navbar

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68544ec2278c832c865d3ec685d2ce9e