### PR TITLE
Add empty state to MyApplicationsPage

### DIFF
--- a/frontend/src/pages/MyApplicationsPage.tsx
+++ b/frontend/src/pages/MyApplicationsPage.tsx
@@ -34,6 +34,9 @@ export default function MyApplicationsPage() {
     return (
       <div className="text-red-500">Failed to load applications: {error}</div>
     );
+  if (applications.length === 0) {
+    return <div>No applications found.</div>;
+  }
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- handle empty applications list in MyApplicationsPage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68546563ab74832cb6cb9ffd94a1745c