### PR TITLE
Remove sidebar from apply page

### DIFF
--- a/frontend/src/components/layout/PageContainer.tsx
+++ b/frontend/src/components/layout/PageContainer.tsx
@@ -1,20 +1,13 @@
-import { Outlet, useLocation } from "react-router-dom";
+import { Outlet } from "react-router-dom";
 import Navbar from "./Navbar";
-import Sidebar from "./Sidebar";
 
 export default function PageContainer() {
-  const { pathname } = useLocation();
-  const showSidebar = pathname.includes("/apply");
-
   return (
     <div className="min-h-screen flex flex-col">
       <Navbar />
-      <div className="flex flex-1">
-        {showSidebar && <Sidebar />}
-        <main className={`${showSidebar ? "flex-1" : "w-full"} p-4`}>
-          <Outlet />
-        </main>
-      </div>
+      <main className="w-full p-4 flex-1">
+        <Outlet />
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove left Dashboard/Calls sidebar on the call apply page

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_685468a25374832c811eca93b73885f1