### PR TITLE
Rename Calls page to Call

### DIFF
--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -25,7 +25,7 @@ export default function Navbar() {
         {/* Main Links */}
         <div className="flex flex-wrap gap-x-6 mb-2 sm:mb-0 justify-center">
           <Link to="/" className="hover:underline">Home</Link>
-          {token && <Link to="/calls" className="hover:underline">Calls</Link>}
+          {token && <Link to="/call" className="hover:underline">Call</Link>}
           <Link to="/about" className="hover:underline">About</Link>
           {token && role === "applicant" && (
             <Link to="/my-applications" className="hover:underline">My Applications</Link>
@@ -33,7 +33,7 @@ export default function Navbar() {
           {token && (role === "admin" || role === "super_admin") && (
             <>
               <Link to="/dashboard" className="hover:underline">Dashboard</Link>
-              <Link to="/calls/manage" className="hover:underline">Manage Calls</Link>
+              <Link to="/calls/manage" className="hover:underline">Manage Call</Link>
             </>
           )}
           {token && role === "reviewer" && (

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -4,7 +4,7 @@ export default function Sidebar() {
   return (
     <aside className="w-48 bg-gray-100 p-4 space-y-2">
       <Link to="/dashboard">Dashboard</Link>
-      <Link to="/calls/manage">Calls</Link>
+      <Link to="/calls/manage">Call</Link>
     </aside>
   );
 }

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -8,7 +8,7 @@ import CallDetailPage from "./pages/CallDetailPage";
 import CallManagementPage from "./pages/CallManagementPage";
 import CallFormPage from "./pages/CallFormPage";
 import CallPreviewPage from "./pages/CallPreviewPage";
-import CallsPage from "./pages/CallsPage";
+import CallPage from "./pages/CallPage";
 import DashboardPage from "./pages/DashboardPage";
 import LoginPage from "./pages/LoginPage";
 import MyApplicationsPage from "./pages/MyApplicationsPage";
@@ -63,8 +63,8 @@ const applicationRoutes = (
        <Route path="/register" element={<RegisterPage />} />
        <Route path="/review/:reviewId" element={<ReviewPage />} />
        <Route path="/" element={<PageContainer />}>
-         <Route index element={<CallsPage />} />
-         <Route path="calls" element={<CallsPage />} />
+         <Route index element={<CallPage />} />
+         <Route path="call" element={<CallPage />} />
          <Route path="about" element={<AboutPage />} />
         {adminRoutes}
          <Route path="calls/:callId" element={<CallDetailPage />} />

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -44,10 +44,10 @@ export default function AboutPage() {
 
         <div className="text-center">
           <Link
-            to="/calls"
+            to="/call"
             className="inline-block bg-blue-600 text-white px-8 py-3 rounded-lg shadow hover:bg-blue-700 transition"
           >
-            Browse Calls
+            Browse Call
           </Link>
         </div>
       </div>

--- a/frontend/src/pages/CallManagementPage.tsx
+++ b/frontend/src/pages/CallManagementPage.tsx
@@ -43,7 +43,7 @@ export default function CallManagementPage() {
 
   return (
     <div className="space-y-4">
-      <h1 className="text-xl font-bold">Manage Calls</h1>
+      <h1 className="text-xl font-bold">Manage Call</h1>
       {loading && <div>Loading...</div>}
       {error && <div className="text-red-500">Error: {error}</div>}
       <div>

--- a/frontend/src/pages/CallPage.tsx
+++ b/frontend/src/pages/CallPage.tsx
@@ -5,7 +5,7 @@ import { getCalls } from "../api/calls";
 import { Call } from "../types/global";
 import { useAuth } from "../context/AuthProvider";
 
-export default function CallsPage() {
+export default function CallPage() {
   const { show } = useToast();
   const { role } = useAuth();
   const [calls, setCalls] = useState<Call[]>([]);
@@ -18,11 +18,11 @@ export default function CallsPage() {
     getCalls()
       .then((data) => {
         setCalls(data);
-        show("Calls loaded");
+        show("Call loaded");
       })
       .catch((err) => {
         setError(err.message);
-        show("Failed to load calls");
+        show("Failed to load call");
       })
       .finally(() => setLoading(false));
   }, [show]);
@@ -33,7 +33,7 @@ export default function CallsPage() {
 
   return (
     <div>
-      <h1>Open Calls</h1>
+      <h1>Open Call</h1>
       <ul className="list-disc pl-5 space-y-2">
         {calls.map((c) => (
           <li key={c.id} className="flex items-center space-x-4">


### PR DESCRIPTION
## Summary
- rename CallsPage to CallPage and update routes
- update navigation links and labels to use singular "Call"
- adjust About and management pages for the new wording

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6854691deca8832cb5583f90c9197a67