### PR TITLE
Add Call detail link from CallPage

### DIFF
--- a/frontend/src/pages/CallPage.tsx
+++ b/frontend/src/pages/CallPage.tsx
@@ -38,6 +38,9 @@ export default function CallPage() {
         {calls.map((c) => (
           <li key={c.id} className="flex items-center space-x-4">
             <span>{c.title}</span>
+            <Link to={`/calls/${c.id}`} className="text-blue-600 underline">
+              Details
+            </Link>
             <Link to={`/calls/${c.id}/preview`} className="text-blue-600 underline">
               Preview
             </Link>


### PR DESCRIPTION
## Summary
- add `Details` link in the Call list so users can open `CallDetailPage`

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68546ef999f0832c888b9365154d992e