### PR TITLE
Add password reset page

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -15,6 +15,7 @@ import LoginPage from "./pages/LoginPage";
 import MyApplicationsPage from "./pages/MyApplicationsPage";
 import NotFoundPage from "./pages/NotFoundPage";
 import RegisterPage from "./pages/RegisterPage";
+import PasswordResetPage from "./pages/PasswordResetPage";
 import ReviewPage from "./pages/ReviewPage";
 import ReviewerPage from "./pages/ReviewerPage";
 import ApplicationLayout from "./pages/calls/apply/ApplicationLayout";
@@ -60,10 +61,11 @@ const applicationRoutes = (
 
  export default function AppRoutes() {
    return (
-     <Routes>
-       <Route path="/login" element={<LoginPage />} />
-       <Route path="/register" element={<RegisterPage />} />
-       <Route path="/review/:reviewId" element={<ReviewPage />} />
+    <Routes>
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/register" element={<RegisterPage />} />
+      <Route path="/password-reset" element={<PasswordResetPage />} />
+      <Route path="/review/:reviewId" element={<ReviewPage />} />
        <Route path="/" element={<PageContainer />}>
          <Route index element={<HomePage />} />
          <Route path="call" element={<CallPage />} />

--- a/frontend/src/pages/PasswordResetPage.tsx
+++ b/frontend/src/pages/PasswordResetPage.tsx
@@ -1,0 +1,67 @@
+import { useState } from "react";
+import Navbar from "../components/layout/Navbar";
+import { Input } from "../components/ui/Input";
+import { Button } from "../components/ui/Button";
+import { useToast } from "../context/ToastProvider";
+
+export default function PasswordResetPage() {
+  const { show } = useToast();
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async () => {
+    setLoading(true);
+    try {
+      // TODO: integrate password reset API
+      show(
+        "If an account exists for that email, instructions have been sent."
+      );
+    } catch {
+      show("Failed to send password reset instructions.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <Navbar />
+      <section className="w-full bg-gray-50 py-16 px-4 min-h-screen">
+        <div className="max-w-md mx-auto bg-white p-8 rounded-lg shadow-lg">
+          <h1 className="text-2xl font-bold text-center mb-4">
+            Reset Your Password
+          </h1>
+          <p className="text-sm text-gray-600 text-center mb-6">
+            Enter your email and we'll send you reset instructions.
+          </p>
+          <form
+            className="space-y-6"
+            onSubmit={(e) => {
+              e.preventDefault();
+              handleSubmit();
+            }}
+          >
+            <div>
+              <label
+                htmlFor="email"
+                className="block text-sm font-medium text-gray-700"
+              >
+                Email
+              </label>
+              <Input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+              />
+            </div>
+            <Button type="submit" className="w-full" disabled={loading}>
+              {loading ? "Sending..." : "Send Reset Link"}
+            </Button>
+          </form>
+        </div>
+      </section>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- create a simple PasswordResetPage
- register the `/password-reset` route

## Testing
- `pytest` *(fails: ModuleNotFoundError: fastapi)*
- `npm run build` in `frontend` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68546f031ea0832c85d5bd45950d6dab