### PR TITLE
Fix admin navigation

### DIFF
--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -1,5 +1,6 @@
 import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "../../context/AuthProvider";
+import { UserRole } from "../../types/global";
 
 export default function Navbar() {
   const { token, role, logout } = useAuth();
@@ -27,16 +28,16 @@ export default function Navbar() {
           <Link to="/" className="hover:underline">Home</Link>
           {token && <Link to="/call" className="hover:underline">Call</Link>}
           <Link to="/about" className="hover:underline">About</Link>
-          {token && role === "applicant" && (
+          {token && role === UserRole.applicant && (
             <Link to="/applications/me" className="hover:underline">My Applications</Link>
           )}
-          {token && (role === "admin" || role === "super_admin") && (
+          {token && (role === UserRole.admin || role === UserRole.super_admin) && (
             <>
               <Link to="/dashboard" className="hover:underline">Dashboard</Link>
               <Link to="/calls/manage" className="hover:underline">Manage Call</Link>
             </>
           )}
-          {token && role === "reviewer" && (
+          {token && role === UserRole.reviewer && (
             <Link to="/reviewer" className="hover:underline">My Reviews</Link>
           )}
         </div>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -35,7 +35,6 @@ const adminRoutes = (
 
 const applicantRoutes = (
   <Route element={<AuthRoute roles={[UserRole.applicant]} />}>
-    <Route path="my-applications" element={<MyApplicationsPage />} />
     <Route path="applications/me" element={<MyApplicationsPage />} />
   </Route>
 );

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -5,6 +5,7 @@ import { Button } from "../components/ui/Button";
 import Navbar from "../components/layout/Navbar";
 import { useToast } from "../context/ToastProvider";
 import { useAuth } from "../context/AuthProvider";
+import { UserRole } from "../types/global";
 
 export default function LoginPage() {
   const { show } = useToast();
@@ -29,12 +30,12 @@ export default function LoginPage() {
     try {
       const user = await login(email, password);
       show("Logged in successfully");
-      if (user?.role === "admin" || user?.role === "super_admin") {
+      if (user?.role === UserRole.admin || user?.role === UserRole.super_admin) {
         navigate("/dashboard");
-      } else if (user?.role === "reviewer") {
+      } else if (user?.role === UserRole.reviewer) {
         navigate("/reviewer");
-      } else if (user?.role === "applicant") {
-        navigate("/my-applications");
+      } else if (user?.role === UserRole.applicant) {
+        navigate("/applications/me");
       } else {
         navigate("/");
       }


### PR DESCRIPTION
## Summary
- update login redirect logic to use enum constants
- unify My Applications path and redirect
- ensure navbar role checks use enum
- remove obsolete my-applications route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68546dfe53cc832c92e50b382a17a2a5