### PR TITLE
Add home link on NotFoundPage

### DIFF
--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -1,3 +1,13 @@
+import { Link } from "react-router-dom";
+
 export default function NotFoundPage() {
-  return <div>Page not found.</div>;
+  return (
+    <div className="flex flex-col items-center justify-center text-center space-y-4 py-20">
+      <h1 className="text-4xl font-bold">Page not found.</h1>
+      <p>The page you are looking for does not exist.</p>
+      <Link to="/" className="text-blue-600 underline hover:text-blue-800">
+        Go back home
+      </Link>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add a simple 404 page with a link back to the homepage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68546f0e13c0832ca2e59d884b5e2d0a