### PR TITLE
Standardize call route paths

### DIFF
--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -10,7 +10,7 @@ from ..core.enums import UserRole
 router = APIRouter(prefix="/admin", tags=["Admin"])
 
 
-@router.get("/calls", response_model=list[CallRead])
+@router.get("/call", response_model=list[CallRead])
 @role_required(UserRole.admin, UserRole.super_admin)
 def list_calls(db: Session = Depends(get_db)):
     return list(crud_call.get_all(db))

--- a/backend/app/routes/call.py
+++ b/backend/app/routes/call.py
@@ -9,7 +9,7 @@ from ..database import get_db
 from ..crud import call as crud
 from ..schemas import CallCreate, CallRead
 
-router = APIRouter(prefix="/calls", tags=["Call"])
+router = APIRouter(prefix="/call", tags=["Call"])
 
 @router.post('/', response_model=CallRead)
 @role_required(UserRole.admin, UserRole.super_admin)

--- a/frontend/src/api/calls.ts
+++ b/frontend/src/api/calls.ts
@@ -3,15 +3,15 @@ import type { GetCallsResponse, GetCallResponse, CallInput } from "../types/call
 
 
 export function getCalls() {
-  return apiFetch("/calls") as Promise<GetCallsResponse>;
+  return apiFetch("/call") as Promise<GetCallsResponse>;
 }
 
 export function getCall(id: string) {
-  return apiFetch(`/calls/${id}`) as Promise<GetCallResponse>;
+  return apiFetch(`/call/${id}`) as Promise<GetCallResponse>;
 }
 
 export function createCall(data: CallInput) {
-  return apiFetch(`/calls`, {
+  return apiFetch(`/call`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
@@ -19,7 +19,7 @@ export function createCall(data: CallInput) {
 }
 
 export function updateCall(id: string, data: CallInput) {
-  return apiFetch(`/calls/${id}`, {
+  return apiFetch(`/call/${id}`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
@@ -27,5 +27,5 @@ export function updateCall(id: string, data: CallInput) {
 }
 
 export function deleteCall(id: string) {
-  return apiFetch(`/calls/${id}`, { method: "DELETE" });
+  return apiFetch(`/call/${id}`, { method: "DELETE" });
 }

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -33,7 +33,7 @@ export default function Navbar() {
           {token && (role === "admin" || role === "super_admin") && (
             <>
               <Link to="/dashboard" className="hover:underline">Dashboard</Link>
-              <Link to="/calls/manage" className="hover:underline">Manage Call</Link>
+              <Link to="/call/manage" className="hover:underline">Manage Call</Link>
             </>
           )}
           {token && role === "reviewer" && (

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -4,7 +4,7 @@ export default function Sidebar() {
   return (
     <aside className="w-48 bg-gray-100 p-4 space-y-2">
       <Link to="/dashboard">Dashboard</Link>
-      <Link to="/calls/manage">Call</Link>
+      <Link to="/call/manage">Call</Link>
     </aside>
   );
 }

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -26,10 +26,10 @@ import Step4_Submit from "./pages/calls/apply/Step4_Submit";
 const adminRoutes = (
   <Route element={<AuthRoute roles={[UserRole.admin, UserRole.super_admin]} />}>
     <Route path="dashboard" element={<DashboardPage />} />
-    <Route path="calls/manage" element={<CallManagementPage />} />
-    <Route path="calls/manage/new" element={<CallFormPage />} />
-    <Route path="calls/manage/:callId" element={<CallFormPage />} />
-    <Route path="calls/:callId/applications" element={<CallApplicationsPage />} />
+    <Route path="call/manage" element={<CallManagementPage />} />
+    <Route path="call/manage/new" element={<CallFormPage />} />
+    <Route path="call/manage/:callId" element={<CallFormPage />} />
+    <Route path="call/:callId/applications" element={<CallApplicationsPage />} />
   </Route>
 );
 
@@ -48,7 +48,7 @@ const reviewerRoutes = (
 
 const applicationRoutes = (
   <Route element={<AuthRoute roles={[UserRole.applicant]} />}>
-    <Route path="calls/:callId/apply" element={<ApplicationLayout />}>
+    <Route path="call/:callId/apply" element={<ApplicationLayout />}>
       <Route index element={<Navigate to="step1" replace />} />
       <Route path="step1" element={<Step1_CallInfo />} />
       <Route path="step2" element={<Step2_Upload />} />
@@ -69,8 +69,8 @@ const applicationRoutes = (
          <Route path="call" element={<CallPage />} />
          <Route path="about" element={<AboutPage />} />
         {adminRoutes}
-         <Route path="calls/:callId" element={<CallDetailPage />} />
-         <Route path="calls/:callId/preview" element={<CallPreviewPage />} />
+         <Route path="call/:callId" element={<CallDetailPage />} />
+         <Route path="call/:callId/preview" element={<CallPreviewPage />} />
         {applicantRoutes}
         {reviewerRoutes}
         {applicationRoutes}

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -47,7 +47,7 @@ export default function AboutPage() {
             to="/call"
             className="inline-block bg-blue-600 text-white px-8 py-3 rounded-lg shadow hover:bg-blue-700 transition"
           >
-            Browse Call
+            Browse Calls
           </Link>
         </div>
       </div>

--- a/frontend/src/pages/CallDetailPage.tsx
+++ b/frontend/src/pages/CallDetailPage.tsx
@@ -38,7 +38,7 @@ export default function CallDetailPage() {
       <h1 className="text-xl font-bold">{call?.title}</h1>
       <p>{call?.description}</p>
       {role === "applicant" && callId && (
-        <Link to={`/calls/${callId}/apply`}>
+        <Link to={`/call/${callId}/apply`}>
           <Button>Apply</Button>
         </Link>
       )}

--- a/frontend/src/pages/CallFormPage.tsx
+++ b/frontend/src/pages/CallFormPage.tsx
@@ -62,7 +62,7 @@ export default function CallFormPage() {
         await createCall(payload);
         show("Call created");
       }
-      navigate("/calls/manage");
+      navigate("/call/manage");
     } catch (err) {
       setError((err as Error).message);
     } finally {
@@ -114,7 +114,7 @@ export default function CallFormPage() {
           />
         </div>
         <Button type="submit">{callId ? "Update" : "Create"}</Button>
-        <Button type="button" variant="outline" onClick={() => navigate("/calls/manage")}>Cancel</Button>
+        <Button type="button" variant="outline" onClick={() => navigate("/call/manage")}>Cancel</Button>
       </form>
     </div>
   );

--- a/frontend/src/pages/CallManagementPage.tsx
+++ b/frontend/src/pages/CallManagementPage.tsx
@@ -47,7 +47,7 @@ export default function CallManagementPage() {
       {loading && <div>Loading...</div>}
       {error && <div className="text-red-500">Error: {error}</div>}
       <div>
-        <Button onClick={() => navigate("/calls/manage/new")}>Create New Call</Button>
+        <Button onClick={() => navigate("/call/manage/new")}>Create New Call</Button>
       </div>
       <Table>
         <thead>
@@ -62,7 +62,7 @@ export default function CallManagementPage() {
             <tr key={c.id}>
               <td>{c.title}</td>
               <td className="space-x-2">
-                <Button type="button" onClick={() => navigate(`/calls/manage/${c.id}`)}>
+                <Button type="button" onClick={() => navigate(`/call/manage/${c.id}`)}>
                   Edit
                 </Button>
                 <Button type="button" onClick={() => remove(c.id)}>
@@ -70,7 +70,7 @@ export default function CallManagementPage() {
                 </Button>
               </td>
               <td>
-                <Link to={`/calls/${c.id}/applications`}>
+                <Link to={`/call/${c.id}/applications`}>
                   <Button variant="link">Applications</Button>
                 </Link>
               </td>

--- a/frontend/src/pages/CallPage.tsx
+++ b/frontend/src/pages/CallPage.tsx
@@ -38,12 +38,12 @@ export default function CallPage() {
         {calls.map((c) => (
           <li key={c.id} className="flex items-center space-x-4">
             <span>{c.title}</span>
-            <Link to={`/calls/${c.id}/preview`} className="text-blue-600 underline">
+            <Link to={`/call/${c.id}/preview`} className="text-blue-600 underline">
               Preview
             </Link>
             {role === "applicant" && (
               <Link
-                to={`/calls/${c.id}/apply`}
+                to={`/call/${c.id}/apply`}
                 className="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600"
               >
                 Apply

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -53,7 +53,7 @@ export default function HomePage() {
 
         <div className="flex space-x-4">
           <Link
-            to="/calls"
+            to="/call"
             className="bg-blue-600 text-white px-6 py-3 rounded-lg shadow hover:bg-blue-700 transition"
           >
             Browse Calls


### PR DESCRIPTION
## Summary
- standardize API and React routes to `/call`
- update navigation links and pages to use new path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68546f1ffd58832c9249a93ec0a91a33