### PR TITLE
Restrict to single published call

### DIFF
--- a/backend/app/crud/call.py
+++ b/backend/app/crud/call.py
@@ -1,7 +1,15 @@
 from sqlalchemy.orm import Session
 
 from ..models import Call
-from .base import create as _create, get_by_id as _get_by_id, get_all as _get_all, update as _update, delete as _delete, get_all_by_field
+from ..core.enums import CallStatus
+from .base import (
+    create as _create,
+    get_by_id as _get_by_id,
+    get_all as _get_all,
+    update as _update,
+    delete as _delete,
+    get_all_by_field,
+)
 
 
 def create(db: Session, data: dict) -> Call:
@@ -14,6 +22,11 @@ def get_by_id(db: Session, obj_id, include_deleted: bool = False):
 
 def get_all(db: Session, include_deleted: bool = False):
     return _get_all(db, Call, include_deleted)
+
+
+def get_by_status(db: Session, status: CallStatus, include_deleted: bool = False):
+    """Return all calls with the given status."""
+    return get_all_by_field(db, Call, "status", status, include_deleted)
 
 
 def update(db: Session, obj: Call, data: dict) -> Call:

--- a/backend/app/routes/call.py
+++ b/backend/app/routes/call.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 import uuid
 
 from ..core.security import role_required
-from ..core.enums import UserRole
+from ..core.enums import UserRole, CallStatus
 
 from ..database import get_db
 from ..crud import call as crud
@@ -14,6 +14,14 @@ router = APIRouter(prefix="/call", tags=["Call"])
 @router.post('/', response_model=CallRead)
 @role_required(UserRole.admin, UserRole.super_admin)
 def create_call(data: CallCreate, db: Session = Depends(get_db)):
+    if (
+        data.status == CallStatus.PUBLISHED
+        and crud.get_by_status(db, CallStatus.PUBLISHED)
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="Another call is already published. Set status to a different value.",
+        )
     return crud.create(db, data.dict())
 
 @router.get('/{obj_id}', response_model=CallRead)
@@ -24,7 +32,12 @@ def read_call(obj_id: uuid.UUID, db: Session = Depends(get_db)):
     return obj
 
 @router.get('/', response_model=list[CallRead])
-def read_calls(db: Session = Depends(get_db)):
+def read_calls(
+    status: CallStatus | None = None,
+    db: Session = Depends(get_db),
+):
+    if status is not None:
+        return list(crud.get_by_status(db, status))
     return list(crud.get_all(db))
 
 @router.put('/{obj_id}', response_model=CallRead)
@@ -33,6 +46,15 @@ def update_call(obj_id: uuid.UUID, data: CallCreate, db: Session = Depends(get_d
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="Call not found")
+    if (
+        data.status == CallStatus.PUBLISHED
+        and crud.get_by_status(db, CallStatus.PUBLISHED)
+        and obj.status != CallStatus.PUBLISHED
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="Another call is already published. Set status to a different value.",
+        )
     return crud.update(db, obj, data.dict())
 
 @router.delete('/{obj_id}')

--- a/frontend/src/api/calls.ts
+++ b/frontend/src/api/calls.ts
@@ -2,8 +2,9 @@ import { apiFetch } from "../lib/api";
 import type { GetCallsResponse, GetCallResponse, CallInput } from "../types/calls.types";
 
 
-export function getCalls() {
-  return apiFetch("/call") as Promise<GetCallsResponse>;
+export function getCalls(status?: string) {
+  const query = status ? `?status=${encodeURIComponent(status)}` : "";
+  return apiFetch(`/call${query}`) as Promise<GetCallsResponse>;
 }
 
 export function getCall(id: string) {

--- a/frontend/src/pages/CallFormPage.tsx
+++ b/frontend/src/pages/CallFormPage.tsx
@@ -2,7 +2,7 @@ import { FormEvent, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Input } from "../components/ui/Input";
 import { Button } from "../components/ui/Button";
-import { createCall, updateCall, getCall } from "../api/calls";
+import { createCall, updateCall, getCall, getCalls } from "../api/calls";
 import { CallStatus, Call } from "../types/global";
 import type { CallInput } from "../types/calls.types";
 import { useToast } from "../context/ToastProvider";
@@ -53,6 +53,21 @@ export default function CallFormPage() {
     e.preventDefault();
     setLoading(true);
     setError(null);
+    if (form.status === "PUBLISHED") {
+      try {
+        const published = await getCalls("PUBLISHED");
+        if (
+          published.length > 0 &&
+          (!callId || published[0].id !== callId)
+        ) {
+          setError("Another call is already published. Choose a different status.");
+          setLoading(false);
+          return;
+        }
+      } catch (err) {
+        // ignore errors in checking published call
+      }
+    }
     const payload: CallInput = {
       ...form,
       start_date: form.start_date || undefined,

--- a/frontend/src/pages/CallPage.tsx
+++ b/frontend/src/pages/CallPage.tsx
@@ -15,7 +15,7 @@ export default function CallPage() {
   useEffect(() => {
     setLoading(true);
     setError(null);
-    getCalls()
+    getCalls("PUBLISHED")
       .then((data) => {
         setCalls(data);
         show("Call loaded");


### PR DESCRIPTION
## Summary
- prevent creation of more than one published call
- support filtering calls by status
- filter published calls for applicants
- warn admins in call form if another call is already published

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_685473788690832c9bd4a6ebde30f389