### PR TITLE
Fix token persistence in AuthProvider

### DIFF
--- a/frontend/src/context/AuthProvider.tsx
+++ b/frontend/src/context/AuthProvider.tsx
@@ -59,6 +59,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const login = async (email: string, password: string) => {
     const data = await apiLogin({ email, password });
     const user = decodeToken(data.access_token);
+    localStorage.setItem("token", data.access_token);
     setState({ token: data.access_token, user });
     return user;
   };
@@ -74,6 +75,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   const logout = () => {
+    localStorage.removeItem("token");
     setState({ token: null, user: null });
   };
 


### PR DESCRIPTION
## Summary
- persist token immediately on login to ensure subsequent requests are authenticated
- remove token from storage on logout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6854753259d0832cb5b06338926ccf2e