### PR TITLE
Implement new pages and navigation

### DIFF
--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -28,6 +28,9 @@ export default function Navbar() {
           <Link to="/" className="hover:underline">Home</Link>
           {token && <Link to="/call" className="hover:underline">Call</Link>}
           <Link to="/about" className="hover:underline">About</Link>
+          <Link to="/terms" className="hover:underline">Terms</Link>
+          <Link to="/privacy" className="hover:underline">Privacy</Link>
+          {token && <Link to="/settings" className="hover:underline">Settings</Link>}
           {token && role === UserRole.applicant && (
             <Link to="/applications/me" className="hover:underline">My Applications</Link>
           )}
@@ -36,6 +39,9 @@ export default function Navbar() {
               <Link to="/dashboard" className="hover:underline">Dashboard</Link>
               <Link to="/call/manage" className="hover:underline">Manage Call</Link>
             </>
+          )}
+          {token && role === UserRole.super_admin && (
+            <Link to="/admin/users" className="hover:underline">User Management</Link>
           )}
           {token && role === UserRole.reviewer && (
             <Link to="/reviewer" className="hover:underline">My Reviews</Link>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -17,6 +17,10 @@ import RegisterPage from "./pages/RegisterPage";
 import PasswordResetPage from "./pages/PasswordResetPage";
 import ReviewPage from "./pages/ReviewPage";
 import ReviewerPage from "./pages/ReviewerPage";
+import SettingsPage from "./pages/SettingsPage";
+import AdminUserManagementPage from "./pages/AdminUserManagementPage";
+import TermsPage from "./pages/TermsPage";
+import PrivacyPage from "./pages/PrivacyPage";
 import ApplicationLayout from "./pages/calls/apply/ApplicationLayout";
 import Step1_CallInfo from "./pages/calls/apply/Step1_CallInfo";
 import Step2_Upload from "./pages/calls/apply/Step2_Upload";
@@ -57,24 +61,40 @@ const applicationRoutes = (
   </Route>
 );
 
+const accountRoutes = (
+  <Route element={<AuthRoute />}>
+    <Route path="settings" element={<SettingsPage />} />
+  </Route>
+);
+
+const superAdminRoutes = (
+  <Route element={<AuthRoute roles={[UserRole.super_admin]} />}>
+    <Route path="admin/users" element={<AdminUserManagementPage />} />
+  </Route>
+);
+
  export default function AppRoutes() {
    return (
      <Routes>
        <Route path="/login" element={<LoginPage />} />
        <Route path="/register" element={<RegisterPage />} />
       <Route element={<AuthRoute roles={[UserRole.reviewer]} />}> 
-        <Route path="/review/:reviewId" element={<ReviewPage />} />
-      </Route>
-       <Route path="/" element={<PageContainer />}>
-         <Route index element={<HomePage />} />
-         <Route path="call" element={<CallPage />} />
-         <Route path="about" element={<AboutPage />} />
+      <Route path="/review/:reviewId" element={<ReviewPage />} />
+    </Route>
+      <Route path="/" element={<PageContainer />}>
+        <Route index element={<HomePage />} />
+        <Route path="call" element={<CallPage />} />
+        <Route path="about" element={<AboutPage />} />
+        <Route path="terms" element={<TermsPage />} />
+        <Route path="privacy" element={<PrivacyPage />} />
         {adminRoutes}
-         <Route path="call/:callId" element={<CallDetailPage />} />
+        {superAdminRoutes}
+        <Route path="call/:callId" element={<CallDetailPage />} />
         {applicantRoutes}
         {reviewerRoutes}
         {applicationRoutes}
-       </Route>
+        {accountRoutes}
+      </Route>
        <Route path="*" element={<NotFoundPage />} />
      </Routes>
    );

--- a/frontend/src/pages/AdminUserManagementPage.tsx
+++ b/frontend/src/pages/AdminUserManagementPage.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { Input } from "../components/ui/Input";
+import { Button } from "../components/ui/Button";
+import { UserRole } from "../types/global";
+
+interface UserItem {
+  email: string;
+  role: UserRole;
+}
+
+export default function AdminUserManagementPage() {
+  const [users, setUsers] = useState<UserItem[]>([]);
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<UserRole>(UserRole.applicant);
+
+  const handleAdd = (e: React.FormEvent) => {
+    e.preventDefault();
+    console.log("Create user", { email, role });
+    setUsers((prev) => [...prev, { email, role }]);
+    setEmail("");
+  };
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-xl font-bold">User Management</h1>
+      <form onSubmit={handleAdd} className="space-y-4 max-w-md">
+        <div>
+          <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+            Email
+          </label>
+          <Input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label htmlFor="role" className="block text-sm font-medium text-gray-700">
+            Role
+          </label>
+          <select
+            id="role"
+            value={role}
+            onChange={(e) => setRole(e.target.value as UserRole)}
+            className="w-full border rounded p-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            <option value={UserRole.applicant}>applicant</option>
+            <option value={UserRole.reviewer}>reviewer</option>
+            <option value={UserRole.admin}>admin</option>
+          </select>
+        </div>
+        <Button type="submit">Add User</Button>
+      </form>
+      <table className="min-w-full border divide-y divide-gray-200">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Email
+            </th>
+            <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Role
+            </th>
+          </tr>
+        </thead>
+        <tbody className="bg-white divide-y divide-gray-200">
+          {users.map((u, idx) => (
+            <tr key={idx}>
+              <td className="px-4 py-2 whitespace-nowrap">{u.email}</td>
+              <td className="px-4 py-2 whitespace-nowrap">{u.role}</td>
+            </tr>
+          ))}
+          {users.length === 0 && (
+            <tr>
+              <td className="px-4 py-2" colSpan={2}>
+                No users yet.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/pages/PrivacyPage.tsx
+++ b/frontend/src/pages/PrivacyPage.tsx
@@ -1,0 +1,10 @@
+export default function PrivacyPage() {
+  return (
+    <section className="w-full py-12 px-4">
+      <div className="max-w-2xl mx-auto">
+        <h1 className="text-2xl font-bold mb-4">Privacy Policy</h1>
+        <p>This is the Privacy Policy</p>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+import { Input } from "../components/ui/Input";
+import { Button } from "../components/ui/Button";
+
+export default function SettingsPage() {
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [institution, setInstitution] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleSubmit = () => {
+    console.log("Update settings", {
+      firstName,
+      lastName,
+      institution,
+      password,
+    });
+  };
+
+  return (
+    <section className="w-full bg-white py-12 px-4">
+      <div className="max-w-md mx-auto bg-white p-6 rounded-lg shadow-md">
+        <h1 className="text-2xl font-bold mb-6 text-center">Account Settings</h1>
+        <form
+          className="space-y-4"
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSubmit();
+          }}
+        >
+          <div>
+            <label htmlFor="firstName" className="block text-sm font-medium text-gray-700">
+              First Name
+            </label>
+            <Input
+              id="firstName"
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+            />
+          </div>
+          <div>
+            <label htmlFor="lastName" className="block text-sm font-medium text-gray-700">
+              Last Name
+            </label>
+            <Input
+              id="lastName"
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+            />
+          </div>
+          <div>
+            <label htmlFor="institution" className="block text-sm font-medium text-gray-700">
+              Institution (optional)
+            </label>
+            <Input
+              id="institution"
+              value={institution}
+              onChange={(e) => setInstitution(e.target.value)}
+            />
+          </div>
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+              Password
+            </label>
+            <Input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </div>
+          <Button type="submit" className="w-full">
+            Save Changes
+          </Button>
+        </form>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/TermsPage.tsx
+++ b/frontend/src/pages/TermsPage.tsx
@@ -1,0 +1,10 @@
+export default function TermsPage() {
+  return (
+    <section className="w-full py-12 px-4">
+      <div className="max-w-2xl mx-auto">
+        <h1 className="text-2xl font-bold mb-4">Terms of Service</h1>
+        <p>This is the Terms of Service</p>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add SettingsPage for users to update profile data
- add AdminUserManagementPage for super admins
- provide static Terms and Privacy pages
- extend AppRoutes with new paths and role guards
- update Navbar to show links based on role

## Testing
- `npm run build` *(fails: missing dependencies and TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68547782b068832c84ac4ec4b8f07e18