### PR TITLE
Add ethics and security tables

### DIFF
--- a/frontend/src/components/application/EthicsIssuesTable.tsx
+++ b/frontend/src/components/application/EthicsIssuesTable.tsx
@@ -1,0 +1,25 @@
+import Table from "../ui/Table";
+
+const ethicsQuestions = [
+  "Does your research involve human participants?",
+  "Does it involve the collection or processing of personal data?",
+  "Does it involve the use of animals?",
+  "Could your work cause environmental or health and safety concerns?",
+];
+
+export default function EthicsIssuesTable() {
+  return (
+    <div className="space-y-2">
+      <h3 className="font-medium">Ethics Issues</h3>
+      <Table>
+        <tbody>
+          {ethicsQuestions.map((q, i) => (
+            <tr key={i}>
+              <td>{q}</td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </div>
+  );
+}

--- a/frontend/src/components/application/SecurityIssuesTable.tsx
+++ b/frontend/src/components/application/SecurityIssuesTable.tsx
@@ -1,0 +1,24 @@
+import Table from "../ui/Table";
+
+const securityQuestions = [
+  "Does your project involve dual-use items or technology?",
+  "Will it use or produce security sensitive data?",
+  "Could the results be misused for malicious purposes?",
+];
+
+export default function SecurityIssuesTable() {
+  return (
+    <div className="space-y-2">
+      <h3 className="font-medium">Security Issues</h3>
+      <Table>
+        <tbody>
+          {securityQuestions.map((q, i) => (
+            <tr key={i}>
+              <td>{q}</td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new components for ethics/security issue checklists
- show these tables on step 8 of the application flow

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68547c25d9c0832cbacc0b35023ea97a