### PR TITLE
Enable proposal and CV uploads

### DIFF
--- a/frontend/src/api/applications.ts
+++ b/frontend/src/api/applications.ts
@@ -24,6 +24,24 @@ export function uploadAttachment(applicationId: string, file: File) {
   }) as Promise<UploadAttachmentResponse>;
 }
 
+export function uploadProposal(applicationId: string, file: File) {
+  const formData = new FormData();
+  formData.append("proposal", file);
+  return apiFetch(`/applications/${applicationId}/upload_file`, {
+    method: "POST",
+    body: formData,
+  }) as Promise<UploadAttachmentResponse>;
+}
+
+export function uploadCV(applicationId: string, file: File) {
+  const formData = new FormData();
+  formData.append("cv", file);
+  return apiFetch(`/applications/${applicationId}/upload_file`, {
+    method: "POST",
+    body: formData,
+  }) as Promise<UploadAttachmentResponse>;
+}
+
 export function getApplications() {
   return apiFetch(`/applications`) as Promise<any[]>;
 }

--- a/frontend/src/context/ApplicationProvider.tsx
+++ b/frontend/src/context/ApplicationProvider.tsx
@@ -2,6 +2,8 @@ import { createContext, useContext, useEffect, useState, ReactNode } from "react
 import {
   createApplication as apiCreateApplication,
   uploadAttachment as apiUploadAttachment,
+  uploadProposal as apiUploadProposal,
+  uploadCV as apiUploadCV,
   deleteAttachment as apiDeleteAttachment,
   updateApplication,
   getApplicationAttachments,
@@ -18,6 +20,8 @@ interface ApplicationContextValue {
   attachments: Attachment[];
   createApplication: () => Promise<boolean>;
   uploadAttachment: (file: File) => Promise<boolean>;
+  uploadProposal: (file: File) => Promise<boolean>;
+  uploadCV: (file: File) => Promise<boolean>;
   deleteAttachment: (id: string) => Promise<boolean>;
   submitApplication: () => Promise<boolean>;
 }
@@ -28,6 +32,8 @@ const ApplicationContext = createContext<ApplicationContextValue>({
   attachments: [],
   createApplication: async () => false,
   uploadAttachment: async () => false,
+  uploadProposal: async () => false,
+  uploadCV: async () => false,
   deleteAttachment: async () => false,
   submitApplication: async () => false,
 });
@@ -106,6 +112,28 @@ export function ApplicationProvider({
     }
   };
 
+  const uploadProposal = async (file: File) => {
+    if (!applicationId) return false;
+    try {
+      await apiUploadProposal(applicationId, file);
+      return true;
+    } catch {
+      show("Failed to upload proposal");
+      return false;
+    }
+  };
+
+  const uploadCV = async (file: File) => {
+    if (!applicationId) return false;
+    try {
+      await apiUploadCV(applicationId, file);
+      return true;
+    } catch {
+      show("Failed to upload CV");
+      return false;
+    }
+  };
+
   const deleteAttachment = async (id: string) => {
     try {
       await apiDeleteAttachment(id);
@@ -139,6 +167,8 @@ export function ApplicationProvider({
         attachments,
         createApplication,
         uploadAttachment,
+        uploadProposal,
+        uploadCV,
         deleteAttachment,
         submitApplication,
       }}

--- a/frontend/src/pages/calls/apply/Step7_ProposalCV.tsx
+++ b/frontend/src/pages/calls/apply/Step7_ProposalCV.tsx
@@ -3,7 +3,7 @@ import { useApplication } from "../../../context/ApplicationProvider";
 import { useToast } from "../../../context/ToastProvider";
 
 export default function Step7_ProposalCV() {
-  const { uploadProposal, uploadCV, application } = useApplication();
+  const { uploadProposal, uploadCV } = useApplication();
   const { show } = useToast();
   const [loadingProposal, setLoadingProposal] = useState(false);
   const [loadingCV, setLoadingCV] = useState(false);


### PR DESCRIPTION
## Summary
- add uploadProposal/uploadCV API helpers
- expose proposal and CV upload methods from ApplicationProvider
- clean up Step 7 Proposal/CV page

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68547c27a180832ca7b0a7948394d4de