### PR TITLE
Add mobility entries support

### DIFF
--- a/backend/app/routes/mobility_entry.py
+++ b/backend/app/routes/mobility_entry.py
@@ -23,6 +23,14 @@ def read_mobility_entry(obj_id: uuid.UUID, db: Session = Depends(get_db)):
 def read_mobility_entries(db: Session = Depends(get_db)):
     return list(crud.get_all(db))
 
+
+@router.get('/application_form/{application_form_id}', response_model=list[MobilityEntryRead])
+def read_mobility_entries_by_application_form(
+    application_form_id: uuid.UUID, db: Session = Depends(get_db)
+):
+    """Return mobility entries belonging to a specific application form."""
+    return list(crud.get_mobility_entries_by_application_form_id(db, application_form_id))
+
 @router.put('/{obj_id}', response_model=MobilityEntryRead)
 def update_mobility_entry(obj_id: uuid.UUID, data: MobilityEntryCreate, db: Session = Depends(get_db)):
     obj = crud.get_by_id(db, obj_id)

--- a/frontend/src/api/mobilityEntries.ts
+++ b/frontend/src/api/mobilityEntries.ts
@@ -1,0 +1,26 @@
+import { apiFetch } from "../lib/api";
+import type { MobilityEntryInput, MobilityEntry } from "../types/mobility.types";
+
+export function getMobilityEntries(applicationFormId: string) {
+  return apiFetch(`/mobility_entries/application_form/${applicationFormId}`) as Promise<MobilityEntry[]>;
+}
+
+export function createMobilityEntry(applicationFormId: string, data: MobilityEntryInput) {
+  return apiFetch(`/mobility_entries`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ ...data, application_form_id: applicationFormId }),
+  }) as Promise<MobilityEntry>;
+}
+
+export function updateMobilityEntry(id: string, data: MobilityEntryInput) {
+  return apiFetch(`/mobility_entries/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  }) as Promise<MobilityEntry>;
+}
+
+export function deleteMobilityEntry(id: string) {
+  return apiFetch(`/mobility_entries/${id}`, { method: "DELETE" });
+}

--- a/frontend/src/context/ApplicationProvider.tsx
+++ b/frontend/src/context/ApplicationProvider.tsx
@@ -6,9 +6,16 @@ import {
   updateApplication,
   getApplicationAttachments,
 } from "../api/applications";
+import {
+  getMobilityEntries as apiGetMobilityEntries,
+  createMobilityEntry as apiCreateMobilityEntry,
+  updateMobilityEntry as apiUpdateMobilityEntry,
+  deleteMobilityEntry as apiDeleteMobilityEntry,
+} from "../api/mobilityEntries";
 import { getCall } from "../api/calls";
 import { Call } from "../types/global";
 import { Attachment } from "../types/application";
+import type { MobilityEntry, MobilityEntryInput } from "../types/mobility.types";
 import { useToast } from "./ToastProvider";
 
 
@@ -16,9 +23,13 @@ interface ApplicationContextValue {
   call: Call | null;
   applicationId: string | null;
   attachments: Attachment[];
+  mobilityEntries: MobilityEntry[];
   createApplication: () => Promise<boolean>;
   uploadAttachment: (file: File) => Promise<boolean>;
   deleteAttachment: (id: string) => Promise<boolean>;
+  addMobilityEntry: (data: MobilityEntryInput) => Promise<boolean>;
+  updateMobilityEntry: (id: string, data: MobilityEntryInput) => Promise<boolean>;
+  removeMobilityEntry: (id: string) => Promise<boolean>;
   submitApplication: () => Promise<boolean>;
 }
 
@@ -26,9 +37,13 @@ const ApplicationContext = createContext<ApplicationContextValue>({
   call: null,
   applicationId: null,
   attachments: [],
+  mobilityEntries: [],
   createApplication: async () => false,
   uploadAttachment: async () => false,
   deleteAttachment: async () => false,
+  addMobilityEntry: async () => false,
+  updateMobilityEntry: async () => false,
+  removeMobilityEntry: async () => false,
   submitApplication: async () => false,
 });
 
@@ -48,6 +63,7 @@ export function ApplicationProvider({
     localStorage.getItem(`applicationId_${callId}`)
   );
   const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const [mobilityEntries, setMobilityEntries] = useState<MobilityEntry[]>([]);
   const { show } = useToast();
 
   useEffect(() => {
@@ -79,7 +95,19 @@ export function ApplicationProvider({
         show("Failed to load attachments");
       }
     };
+
+    const fetchMobility = async () => {
+      try {
+        const data = await apiGetMobilityEntries(applicationId);
+        setMobilityEntries(data);
+      } catch {
+        setMobilityEntries([]);
+        show("Failed to load mobility entries");
+      }
+    };
+
     fetchAttachments();
+    fetchMobility();
   }, [applicationId, callId, show]);
 
   const createApplication = async () => {
@@ -117,6 +145,40 @@ export function ApplicationProvider({
     }
   };
 
+  const addMobilityEntry = async (data: MobilityEntryInput) => {
+    if (!applicationId) return false;
+    try {
+      const entry = await apiCreateMobilityEntry(applicationId, data);
+      setMobilityEntries((prev) => [...prev, entry]);
+      return true;
+    } catch {
+      show("Failed to add mobility entry");
+      return false;
+    }
+  };
+
+  const updateMobilityEntry = async (id: string, data: MobilityEntryInput) => {
+    try {
+      const entry = await apiUpdateMobilityEntry(id, data);
+      setMobilityEntries((prev) => prev.map((e) => (e.id === id ? entry : e)));
+      return true;
+    } catch {
+      show("Failed to update mobility entry");
+      return false;
+    }
+  };
+
+  const removeMobilityEntry = async (id: string) => {
+    try {
+      await apiDeleteMobilityEntry(id);
+      setMobilityEntries((prev) => prev.filter((e) => e.id !== id));
+      return true;
+    } catch {
+      show("Failed to delete mobility entry");
+      return false;
+    }
+  };
+
   const submitApplication = async () => {
     if (!applicationId) return false;
     try {
@@ -137,9 +199,13 @@ export function ApplicationProvider({
         call,
         applicationId,
         attachments,
+        mobilityEntries,
         createApplication,
         uploadAttachment,
         deleteAttachment,
+        addMobilityEntry,
+        updateMobilityEntry,
+        removeMobilityEntry,
         submitApplication,
       }}
     >

--- a/frontend/src/pages/calls/apply/Step6_Mobility.tsx
+++ b/frontend/src/pages/calls/apply/Step6_Mobility.tsx
@@ -1,44 +1,39 @@
-import { useState } from "react";
 import { Button } from "../../../components/ui/Button";
 import { useApplication } from "../../../context/ApplicationProvider";
-
-interface MobilityEntry {
-  from_date: string;
-  to_date: string;
-  organisation: string;
-  country: string;
-}
+import type { MobilityEntryInput, MobilityEntry } from "../../../types/mobility.types";
 
 export default function Step6_Mobility() {
-  const { updateField, data } = useApplication();
-  const [entries, setEntries] = useState<MobilityEntry[]>(data.mobility_entries || []);
+  const {
+    mobilityEntries,
+    addMobilityEntry,
+    updateMobilityEntry,
+    removeMobilityEntry,
+  } = useApplication();
 
-  const handleChange = (index: number, field: keyof MobilityEntry, value: string) => {
-    const updated = [...entries];
-    updated[index][field] = value;
-    setEntries(updated);
-    updateField("mobility_entries", updated);
+  const handleChange = (
+    id: string,
+    field: keyof MobilityEntryInput,
+    value: string
+  ) => {
+    const entry = mobilityEntries.find((e) => e.id === id);
+    if (!entry) return;
+    updateMobilityEntry(id, { ...entry, [field]: value });
   };
 
-  const handleAdd = () => {
-    const newEntry = { from_date: "", to_date: "", organisation: "", country: "" };
-    const updated = [...entries, newEntry];
-    setEntries(updated);
-    updateField("mobility_entries", updated);
+  const handleAdd = async () => {
+    await addMobilityEntry({ from_date: "", to_date: "", organisation: "", country: "" });
   };
 
-  const handleRemove = (index: number) => {
-    const updated = entries.filter((_, i) => i !== index);
-    setEntries(updated);
-    updateField("mobility_entries", updated);
+  const handleRemove = (id: string) => {
+    removeMobilityEntry(id);
   };
 
   return (
     <div className="space-y-4">
       <h2 className="text-lg font-semibold">Mobility Entries</h2>
-      {entries.map((entry, index) => (
+      {mobilityEntries.map((entry) => (
         <div
-          key={index}
+          key={entry.id}
           className="grid grid-cols-1 md:grid-cols-4 gap-4 border p-4 rounded-lg shadow-sm"
         >
           <div>
@@ -46,7 +41,7 @@ export default function Step6_Mobility() {
             <input
               type="date"
               value={entry.from_date}
-              onChange={(e) => handleChange(index, "from_date", e.target.value)}
+              onChange={(e) => handleChange(entry.id, "from_date", e.target.value)}
               className="input"
             />
           </div>
@@ -55,7 +50,7 @@ export default function Step6_Mobility() {
             <input
               type="date"
               value={entry.to_date}
-              onChange={(e) => handleChange(index, "to_date", e.target.value)}
+              onChange={(e) => handleChange(entry.id, "to_date", e.target.value)}
               className="input"
             />
           </div>
@@ -64,7 +59,7 @@ export default function Step6_Mobility() {
             <input
               type="text"
               value={entry.organisation}
-              onChange={(e) => handleChange(index, "organisation", e.target.value)}
+              onChange={(e) => handleChange(entry.id, "organisation", e.target.value)}
               className="input"
             />
           </div>
@@ -73,12 +68,12 @@ export default function Step6_Mobility() {
             <input
               type="text"
               value={entry.country}
-              onChange={(e) => handleChange(index, "country", e.target.value)}
+              onChange={(e) => handleChange(entry.id, "country", e.target.value)}
               className="input"
             />
           </div>
           <div className="col-span-1 md:col-span-4 text-right">
-            <Button variant="destructive" onClick={() => handleRemove(index)}>
+            <Button variant="destructive" onClick={() => handleRemove(entry.id)}>
               Remove
             </Button>
           </div>

--- a/frontend/src/types/mobility.types.ts
+++ b/frontend/src/types/mobility.types.ts
@@ -1,0 +1,10 @@
+export interface MobilityEntryInput {
+  from_date: string;
+  to_date: string;
+  organisation?: string;
+  country?: string;
+}
+
+export interface MobilityEntry extends MobilityEntryInput {
+  id: string;
+}


### PR DESCRIPTION
## Summary
- add an API route to list mobility entries by application form
- add MobilityEntry API helpers and types
- expand `ApplicationProvider` with mobility entry state and handlers
- manage mobility entry CRUD from the Mobility step

## Testing
- `npm run build` *(fails: npm registry blocked)*
- `poetry run pytest` *(fails: no pyproject)*

------
https://chatgpt.com/codex/tasks/task_e_68547c2c9414832cbbf14b8aa87f6d5a