### PR TITLE
Add persistence for application steps

### DIFF
--- a/frontend/src/api/applications.ts
+++ b/frontend/src/api/applications.ts
@@ -40,6 +40,18 @@ export function updateApplication(id: string, data: Record<string, unknown>) {
   });
 }
 
+export function getApplication(id: string) {
+  return apiFetch(`/applications/${id}`) as Promise<any>;
+}
+
+export function patchApplication(id: string, data: Record<string, unknown>) {
+  return apiFetch(`/applications/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
 export function getApplicationAttachments(id: string) {
   return apiFetch(`/attachments/application/${id}`) as Promise<Attachment[]>;
 }

--- a/frontend/src/pages/calls/apply/Step2_ApplicantInfo.tsx
+++ b/frontend/src/pages/calls/apply/Step2_ApplicantInfo.tsx
@@ -1,63 +1,31 @@
-import { useState } from "react";
 import { Input } from "../../../components/ui/Input";
-import { useToast } from "../../../context/ToastProvider";
 import { useApplication } from "../../../context/ApplicationProvider";
 
 export default function Step2_ApplicantInfo() {
-  const { applicationData, updateApplication } = useApplication();
-  const { show } = useToast();
-  const [form, setForm] = useState({
-    title: "",
-    surname: "",
-    first_name: "",
-    year_of_birth: "",
-    nationality: "",
-    organisation: "",
-    university: "",
-    department: "",
-    town_or_city: "",
-    country: "",
-    current_position: "",
-    gender: "",
-  });
+  const { application, updateApplicationField } = useApplication();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
-    setForm((prev) => ({ ...prev, [name]: value }));
-  };
-
-  const handleSave = async () => {
-    try {
-      await updateApplication(form);
-      show("Applicant Info saved");
-    } catch (error) {
-      show("Failed to save applicant info");
-    }
+    updateApplicationField(name, value);
   };
 
   return (
     <div className="space-y-4">
       <h2 className="text-lg font-semibold">Applicant Info</h2>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <Input name="title" label="Title" value={form.title} onChange={handleChange} />
-        <Input name="surname" label="Surname" value={form.surname} onChange={handleChange} />
-        <Input name="first_name" label="First Name" value={form.first_name} onChange={handleChange} />
-        <Input name="year_of_birth" label="Year of Birth" value={form.year_of_birth} onChange={handleChange} />
-        <Input name="nationality" label="Nationality" value={form.nationality} onChange={handleChange} />
-        <Input name="organisation" label="Organisation" value={form.organisation} onChange={handleChange} />
-        <Input name="university" label="University" value={form.university} onChange={handleChange} />
-        <Input name="department" label="Department" value={form.department} onChange={handleChange} />
-        <Input name="town_or_city" label="Town or City" value={form.town_or_city} onChange={handleChange} />
-        <Input name="country" label="Country" value={form.country} onChange={handleChange} />
-        <Input name="current_position" label="Current Position" value={form.current_position} onChange={handleChange} />
-        <Input name="gender" label="Gender" value={form.gender} onChange={handleChange} />
+        <Input name="title" label="Title" value={application.title || ""} onChange={handleChange} />
+        <Input name="surname" label="Surname" value={application.surname || ""} onChange={handleChange} />
+        <Input name="first_name" label="First Name" value={application.first_name || ""} onChange={handleChange} />
+        <Input name="year_of_birth" label="Year of Birth" value={application.year_of_birth || ""} onChange={handleChange} />
+        <Input name="nationality" label="Nationality" value={application.nationality || ""} onChange={handleChange} />
+        <Input name="organisation" label="Organisation" value={application.organisation || ""} onChange={handleChange} />
+        <Input name="university" label="University" value={application.university || ""} onChange={handleChange} />
+        <Input name="department" label="Department" value={application.department || ""} onChange={handleChange} />
+        <Input name="town_or_city" label="Town or City" value={application.town_or_city || ""} onChange={handleChange} />
+        <Input name="country" label="Country" value={application.country || ""} onChange={handleChange} />
+        <Input name="current_position" label="Current Position" value={application.current_position || ""} onChange={handleChange} />
+        <Input name="gender" label="Gender" value={application.gender || ""} onChange={handleChange} />
       </div>
-      <button
-        onClick={handleSave}
-        className="mt-4 bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
-      >
-        Save
-      </button>
     </div>
   );
 }

--- a/frontend/src/pages/calls/apply/Step3_ApplicationDetails.tsx
+++ b/frontend/src/pages/calls/apply/Step3_ApplicationDetails.tsx
@@ -1,75 +1,45 @@
-import { useState } from "react";
 import { Input, TextArea, Checkbox } from "../../../components/ui";
-import { useToast } from "../../../context/ToastProvider";
 import { useApplication } from "../../../context/ApplicationProvider";
 
 export default function Step3_ApplicationDetails() {
-  const { updateApplication } = useApplication();
-  const { show } = useToast();
+  const { application, updateApplicationField } = useApplication();
 
-  const [form, setForm] = useState({
-    project_title: "",
-    acronym: "",
-    keywords: "",
-    abstract: "",
-    selected_supervisor: "",
-    has_secondment: false,
-    selected_from_db: false,
-    institution_name: "",
-  });
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
     const { name, value, type, checked } = e.target;
-    setForm((prev) => ({
-      ...prev,
-      [name]: type === "checkbox" ? checked : value,
-    }));
-  };
-
-  const handleSave = async () => {
-    try {
-      await updateApplication(form);
-      show("Application details saved");
-    } catch (error) {
-      show("Failed to save application details");
-    }
+    updateApplicationField(name, type === "checkbox" ? checked : value);
   };
 
   return (
     <div className="space-y-4">
       <h2 className="text-lg font-semibold">Application Details</h2>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <Input name="project_title" label="Project Title" value={form.project_title} onChange={handleChange} />
-        <Input name="acronym" label="Acronym" value={form.acronym} onChange={handleChange} />
-        <Input name="keywords" label="Keywords (semicolon separated)" value={form.keywords} onChange={handleChange} />
-        <Input name="selected_supervisor" label="Selected Supervisor" value={form.selected_supervisor} onChange={handleChange} />
+        <Input name="project_title" label="Project Title" value={application.project_title || ""} onChange={handleChange} />
+        <Input name="acronym" label="Acronym" value={application.acronym || ""} onChange={handleChange} />
+        <Input name="keywords" label="Keywords (semicolon separated)" value={application.keywords || ""} onChange={handleChange} />
+        <Input name="selected_supervisor" label="Selected Supervisor" value={application.selected_supervisor || ""} onChange={handleChange} />
       </div>
-      <TextArea name="abstract" label="Abstract (max 400 words)" value={form.abstract} onChange={handleChange} />
-      <Checkbox name="has_secondment" label="Has Secondment?" checked={form.has_secondment} onChange={handleChange} />
-      {form.has_secondment && (
+      <TextArea name="abstract" label="Abstract (max 400 words)" value={application.abstract || ""} onChange={handleChange} />
+      <Checkbox name="has_secondment" label="Has Secondment?" checked={application.has_secondment || false} onChange={handleChange} />
+      {application.has_secondment && (
         <>
           <Checkbox
             name="selected_from_db"
             label="Selected from DB"
-            checked={form.selected_from_db}
+            checked={application.selected_from_db || false}
             onChange={handleChange}
           />
-          {!form.selected_from_db && (
+          {!application.selected_from_db && (
             <Input
               name="institution_name"
               label="Secondment Institution Name"
-              value={form.institution_name}
+              value={application.institution_name || ""}
               onChange={handleChange}
             />
           )}
         </>
       )}
-      <button
-        onClick={handleSave}
-        className="mt-4 bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
-      >
-        Save
-      </button>
     </div>
   );
 }

--- a/frontend/src/pages/calls/apply/Step6_Mobility.tsx
+++ b/frontend/src/pages/calls/apply/Step6_Mobility.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button } from "../../../components/ui/Button";
 import { useApplication } from "../../../context/ApplicationProvider";
 
@@ -10,27 +10,31 @@ interface MobilityEntry {
 }
 
 export default function Step6_Mobility() {
-  const { updateField, data } = useApplication();
-  const [entries, setEntries] = useState<MobilityEntry[]>(data.mobility_entries || []);
+  const { application, updateApplicationField } = useApplication();
+  const [entries, setEntries] = useState<MobilityEntry[]>(application.mobility_entries || []);
+
+  useEffect(() => {
+    setEntries(application.mobility_entries || []);
+  }, [application.mobility_entries]);
 
   const handleChange = (index: number, field: keyof MobilityEntry, value: string) => {
     const updated = [...entries];
     updated[index][field] = value;
     setEntries(updated);
-    updateField("mobility_entries", updated);
+    updateApplicationField("mobility_entries", updated);
   };
 
   const handleAdd = () => {
     const newEntry = { from_date: "", to_date: "", organisation: "", country: "" };
     const updated = [...entries, newEntry];
     setEntries(updated);
-    updateField("mobility_entries", updated);
+    updateApplicationField("mobility_entries", updated);
   };
 
   const handleRemove = (index: number) => {
     const updated = entries.filter((_, i) => i !== index);
     setEntries(updated);
-    updateField("mobility_entries", updated);
+    updateApplicationField("mobility_entries", updated);
   };
 
   return (

--- a/frontend/src/pages/calls/apply/Step8_EthicsSecurity.tsx
+++ b/frontend/src/pages/calls/apply/Step8_EthicsSecurity.tsx
@@ -6,27 +6,31 @@ import EthicsIssuesTable from "../../../components/application/EthicsIssuesTable
 import SecurityIssuesTable from "../../../components/application/SecurityIssuesTable";
 
 export default function Step8_EthicsSecurity() {
-  const { applicationData, updateApplicationData } = useApplication();
+  const { application, updateApplicationField } = useApplication();
   const [ethicsConfirmed, setEthicsConfirmed] = useState(
-    applicationData.ethics_confirmed || false
+    application.ethics_confirmed || false
   );
   const [ethicalDescription, setEthicalDescription] = useState(
-    applicationData.ethical_dimension_description || ""
+    application.ethical_dimension_description || ""
   );
   const [complianceText, setComplianceText] = useState(
-    applicationData.compliance_text || ""
+    application.compliance_text || ""
   );
   const [securitySelfAssessment, setSecuritySelfAssessment] = useState(
-    applicationData.security_self_assessment_text || ""
+    application.security_self_assessment_text || ""
   );
 
   const handleChange = () => {
-    updateApplicationData({
-      ethics_confirmed: ethicsConfirmed,
-      ethical_dimension_description: ethicalDescription,
-      compliance_text: complianceText,
-      security_self_assessment_text: securitySelfAssessment,
-    });
+    updateApplicationField("ethics_confirmed", ethicsConfirmed);
+    updateApplicationField(
+      "ethical_dimension_description",
+      ethicalDescription
+    );
+    updateApplicationField("compliance_text", complianceText);
+    updateApplicationField(
+      "security_self_assessment_text",
+      securitySelfAssessment
+    );
   };
 
   return (


### PR DESCRIPTION
## Summary
- save application details in context
- expose helper to update a single application field
- load application info from API when creating or opening a draft
- store applicant info, application details, mobility entries and ethics data via new helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68547c21006c832c9fb57841a8eb6d0b