### PR TITLE
Add reusable form inputs

### DIFF
--- a/frontend/src/components/ui/Checkbox.tsx
+++ b/frontend/src/components/ui/Checkbox.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { cn } from "../../lib/utils";
+
+export interface CheckboxProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+}
+
+export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
+  ({ className, label, ...props }, ref) => {
+    return (
+      <label className="flex items-center space-x-2">
+        <input
+          type="checkbox"
+          ref={ref}
+          {...props}
+          className={cn(
+            "h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500",
+            className
+          )}
+        />
+        {label && <span className="text-sm">{label}</span>}
+      </label>
+    );
+  }
+);
+
+Checkbox.displayName = "Checkbox";

--- a/frontend/src/components/ui/DatePicker.tsx
+++ b/frontend/src/components/ui/DatePicker.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { Input, InputProps } from "./Input";
+
+export interface DatePickerProps extends InputProps {}
+
+export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
+  (props, ref) => <Input type="date" ref={ref} {...props} />
+);
+
+DatePicker.displayName = "DatePicker";

--- a/frontend/src/components/ui/FileInput.tsx
+++ b/frontend/src/components/ui/FileInput.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { Input, InputProps } from "./Input";
+
+export interface FileInputProps extends InputProps {}
+
+export const FileInput = React.forwardRef<HTMLInputElement, FileInputProps>(
+  (props, ref) => <Input type="file" ref={ref} {...props} />
+);
+
+FileInput.displayName = "FileInput";

--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { cn } from "../../lib/utils";
+
+export interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {}
+
+export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ className, children, ...props }, ref) => (
+    <select
+      ref={ref}
+      {...props}
+      className={cn(
+        "flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500",
+        className
+      )}
+    >
+      {children}
+    </select>
+  )
+);
+
+Select.displayName = "Select";

--- a/frontend/src/components/ui/Textarea.tsx
+++ b/frontend/src/components/ui/Textarea.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { cn } from "../../lib/utils";
+
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => (
+    <textarea
+      ref={ref}
+      {...props}
+      className={cn(
+        "flex w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500",
+        className
+      )}
+    />
+  )
+);
+
+Textarea.displayName = "Textarea";

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -1,0 +1,11 @@
+export * from "./Button";
+export { default as Card } from "./Card";
+export { default as ConfirmModal } from "./ConfirmModal";
+export { default as DocumentList } from "./DocumentList";
+export * from "./Input";
+export * from "./Checkbox";
+export * from "./Textarea";
+export * from "./Select";
+export * from "./DatePicker";
+export * from "./FileInput";
+export * from "./Table";

--- a/frontend/src/pages/calls/apply/Step3_ApplicationDetails.tsx
+++ b/frontend/src/pages/calls/apply/Step3_ApplicationDetails.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Input, TextArea, Checkbox } from "../../../components/ui";
+import { Input, Textarea, Checkbox } from "../../../components/ui";
 import { useToast } from "../../../context/ToastProvider";
 import { useApplication } from "../../../context/ApplicationProvider";
 
@@ -18,7 +18,7 @@ export default function Step3_ApplicationDetails() {
     institution_name: "",
   });
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextareaElement>) => {
     const { name, value, type, checked } = e.target;
     setForm((prev) => ({
       ...prev,
@@ -44,7 +44,7 @@ export default function Step3_ApplicationDetails() {
         <Input name="keywords" label="Keywords (semicolon separated)" value={form.keywords} onChange={handleChange} />
         <Input name="selected_supervisor" label="Selected Supervisor" value={form.selected_supervisor} onChange={handleChange} />
       </div>
-      <TextArea name="abstract" label="Abstract (max 400 words)" value={form.abstract} onChange={handleChange} />
+      <Textarea name="abstract" label="Abstract (max 400 words)" value={form.abstract} onChange={handleChange} />
       <Checkbox name="has_secondment" label="Has Secondment?" checked={form.has_secondment} onChange={handleChange} />
       {form.has_secondment && (
         <>

--- a/frontend/src/pages/calls/apply/Step4_DocumentsUpload.tsx
+++ b/frontend/src/pages/calls/apply/Step4_DocumentsUpload.tsx
@@ -3,6 +3,7 @@ import { useToast } from "../../../context/ToastProvider";
 import { useApplication } from "../../../context/ApplicationProvider";
 import DocumentList from "../../../components/ui/DocumentList";
 
+import { FileInput } from "../../../components/ui";
 export default function Step4_DocumentsUpload() {
   const { uploadAttachment, attachments, deleteAttachment } = useApplication();
   const { show } = useToast();
@@ -30,13 +31,7 @@ export default function Step4_DocumentsUpload() {
     <div className="space-y-4">
       <div>
         <label className="font-medium">Upload Required Documents</label>
-        <input
-          type="file"
-          accept="application/pdf,image/jpeg,image/jpg"
-          onChange={handleChange}
-          disabled={loading}
-          className="block mt-2"
-        />
+        <FileInput accept="application/pdf,image/jpeg,image/jpg" onChange={handleChange} disabled={loading} className="block mt-2" />
       </div>
 
       <DocumentList documents={attachments} onDelete={deleteAttachment} />

--- a/frontend/src/pages/calls/apply/Step6_Mobility.tsx
+++ b/frontend/src/pages/calls/apply/Step6_Mobility.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Button } from "../../../components/ui/Button";
+import { Button, Input, DatePicker } from "../../../components/ui";
 import { useApplication } from "../../../context/ApplicationProvider";
 
 interface MobilityEntry {
@@ -43,38 +43,30 @@ export default function Step6_Mobility() {
         >
           <div>
             <label className="block text-sm font-medium">From</label>
-            <input
-              type="date"
+            <DatePicker
               value={entry.from_date}
               onChange={(e) => handleChange(index, "from_date", e.target.value)}
-              className="input"
             />
           </div>
           <div>
             <label className="block text-sm font-medium">To</label>
-            <input
-              type="date"
+            <DatePicker
               value={entry.to_date}
               onChange={(e) => handleChange(index, "to_date", e.target.value)}
-              className="input"
             />
           </div>
           <div>
             <label className="block text-sm font-medium">Organisation</label>
-            <input
-              type="text"
+            <Input type="text"
               value={entry.organisation}
               onChange={(e) => handleChange(index, "organisation", e.target.value)}
-              className="input"
             />
           </div>
           <div>
             <label className="block text-sm font-medium">Country</label>
-            <input
-              type="text"
+            <Input type="text"
               value={entry.country}
               onChange={(e) => handleChange(index, "country", e.target.value)}
-              className="input"
             />
           </div>
           <div className="col-span-1 md:col-span-4 text-right">

--- a/frontend/src/pages/calls/apply/Step7_ProposalCV.tsx
+++ b/frontend/src/pages/calls/apply/Step7_ProposalCV.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useApplication } from "../../../context/ApplicationProvider";
 import { useToast } from "../../../context/ToastProvider";
 
+import { FileInput } from "../../../components/ui";
 export default function Step7_ProposalCV() {
   const { uploadProposal, uploadCV, application } = useApplication();
   const { show } = useToast();
@@ -44,13 +45,12 @@ export default function Step7_ProposalCV() {
         >
           Download Proposal Template
         </a>
-        <input
-          type="file"
-          accept="application/pdf"
-          onChange={(e) => handleUpload(e, "proposal")}
-          disabled={loadingProposal}
-          className="mt-2"
-        />
+          <FileInput
+            accept="application/pdf"
+            onChange={(e) => handleUpload(e, "proposal")}
+            disabled={loadingProposal}
+            className="mt-2"
+          />
       </div>
 
       <div>
@@ -66,13 +66,12 @@ export default function Step7_ProposalCV() {
         >
           Download CV Template
         </a>
-        <input
-          type="file"
-          accept="application/pdf"
-          onChange={(e) => handleUpload(e, "cv")}
-          disabled={loadingCV}
-          className="mt-2"
-        />
+          <FileInput
+            accept="application/pdf"
+            onChange={(e) => handleUpload(e, "cv")}
+            disabled={loadingCV}
+            className="mt-2"
+          />
       </div>
 
       {error && <div className="text-red-500">Error: {error}</div>}


### PR DESCRIPTION
## Summary
- add Checkbox, Textarea, Select, DatePicker and FileInput components
- re-export all UI components from a new `index.ts`
- use these inputs in application step pages for consistency

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68547c23bce8832cace4005861677379