### PR TITLE
Add field-specific document uploads

### DIFF
--- a/frontend/src/api/applications.ts
+++ b/frontend/src/api/applications.ts
@@ -15,9 +15,10 @@ export function createApplication(callId: string) {
   }) as Promise<CreateApplicationResponse>;
 }
 
-export function uploadAttachment(applicationId: string, file: File) {
+export function uploadAttachment(applicationId: string, file: File, field: string) {
   const formData = new FormData();
   formData.append("upload", file);
+  formData.append("field", field);
   return apiFetch(`/applications/${applicationId}/upload_file`, {
     method: "POST",
     body: formData,

--- a/frontend/src/components/ui/DocumentList.tsx
+++ b/frontend/src/components/ui/DocumentList.tsx
@@ -19,7 +19,9 @@ export default function DocumentList({
     <ul className="space-y-2">
       {documents.map((doc) => (
         <li key={doc.id} className="flex justify-between border p-2 rounded">
-          <span>{doc.doc_name}</span>
+          <span>
+            {doc.field_name ? `${doc.field_name}: ${doc.doc_name}` : doc.doc_name}
+          </span>
           {onDelete && (
             <>
               <button

--- a/frontend/src/context/ApplicationProvider.tsx
+++ b/frontend/src/context/ApplicationProvider.tsx
@@ -17,7 +17,7 @@ interface ApplicationContextValue {
   applicationId: string | null;
   attachments: Attachment[];
   createApplication: () => Promise<boolean>;
-  uploadAttachment: (file: File) => Promise<boolean>;
+  uploadAttachment: (file: File, field: string) => Promise<boolean>;
   deleteAttachment: (id: string) => Promise<boolean>;
   submitApplication: () => Promise<boolean>;
 }
@@ -94,10 +94,10 @@ export function ApplicationProvider({
     }
   };
 
-  const uploadAttachment = async (file: File) => {
+  const uploadAttachment = async (file: File, field: string) => {
     if (!applicationId) return false;
     try {
-      const data = await apiUploadAttachment(applicationId, file);
+      const data = await apiUploadAttachment(applicationId, file, field);
       setAttachments((prev) => [...prev, data]);
       return true;
     } catch {

--- a/frontend/src/pages/calls/apply/Step4_DocumentsUpload.tsx
+++ b/frontend/src/pages/calls/apply/Step4_DocumentsUpload.tsx
@@ -9,13 +9,16 @@ export default function Step4_DocumentsUpload() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const handleChange = async (e: ChangeEvent<HTMLInputElement>) => {
+  const handleChange = async (
+    e: ChangeEvent<HTMLInputElement>,
+    field: string
+  ) => {
     const file = e.target.files?.[0];
     if (!file) return;
     setLoading(true);
     setError(null);
     try {
-      await uploadAttachment(file);
+      await uploadAttachment(file, field);
       show("File uploaded");
     } catch (err) {
       setError((err as Error).message);
@@ -27,19 +30,36 @@ export default function Step4_DocumentsUpload() {
   };
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       <div>
-        <label className="font-medium">Upload Required Documents</label>
+        <label className="font-medium">Passport or ID</label>
         <input
           type="file"
           accept="application/pdf,image/jpeg,image/jpg"
-          onChange={handleChange}
+          onChange={(e) => handleChange(e, "passport_or_id")}
           disabled={loading}
           className="block mt-2"
         />
+        <DocumentList
+          documents={attachments.filter((a) => a.field_name === "passport_or_id")}
+          onDelete={deleteAttachment}
+        />
       </div>
 
-      <DocumentList documents={attachments} onDelete={deleteAttachment} />
+      <div>
+        <label className="font-medium">PhD Certificate</label>
+        <input
+          type="file"
+          accept="application/pdf,image/jpeg,image/jpg"
+          onChange={(e) => handleChange(e, "phd_certificate")}
+          disabled={loading}
+          className="block mt-2"
+        />
+        <DocumentList
+          documents={attachments.filter((a) => a.field_name === "phd_certificate")}
+          onDelete={deleteAttachment}
+        />
+      </div>
 
       {error && <div className="text-red-500">Error: {error}</div>}
     </div>

--- a/frontend/src/types/application.ts
+++ b/frontend/src/types/application.ts
@@ -1,4 +1,5 @@
 export interface Attachment {
   id: string;
   doc_name: string;
+  field_name?: string;
 }

--- a/frontend/src/types/applications.types.ts
+++ b/frontend/src/types/applications.types.ts
@@ -9,4 +9,5 @@ export interface CreateApplicationResponse {
 export interface UploadAttachmentResponse {
   id: string;
   doc_name: string;
+  field_name?: string;
 }


### PR DESCRIPTION
## Summary
- support field name when uploading attachments
- display document name with target field
- show documents per field in step 4

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68547c2e66b0832c946d6447eec71b40