### PR TITLE
Fix 404 for settings and policy pages

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,6 +5,7 @@ COPY src ./src
 RUN npm install && npm run build
 
 FROM nginx:alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+
+    location / {
+        try_files $uri /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- serve React SPA routes correctly in nginx

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68547ca96d34832c9a78bce82ae3cbfe