### PR TITLE
Fix ApplicationProvider update logic

### DIFF
--- a/frontend/src/context/ApplicationProvider.tsx
+++ b/frontend/src/context/ApplicationProvider.tsx
@@ -8,6 +8,7 @@ import {
   updateApplication,
   getApplication,
   getApplicationAttachments,
+  patchApplication,
 } from "../api/applications";
 import {
   getMobilityEntries as apiGetMobilityEntries,
@@ -30,6 +31,8 @@ interface ApplicationContextValue {
   mobilityEntries: MobilityEntry[];
   createApplication: () => Promise<boolean>;
   uploadAttachment: (file: File, field: string) => Promise<boolean>;
+  uploadProposal: (file: File) => Promise<boolean>;
+  uploadCV: (file: File) => Promise<boolean>;
   deleteAttachment: (id: string) => Promise<boolean>;
   addMobilityEntry: (data: MobilityEntryInput) => Promise<boolean>;
   updateMobilityEntry: (id: string, data: MobilityEntryInput) => Promise<boolean>;
@@ -121,10 +124,8 @@ export function ApplicationProvider({
       }
     };
 
-    fetchAttachments();
-    getApplication(applicationId)
-      .then(setApplication)
-      .catch(() => setApplication({}));
+    fetchData();
+    fetchMobility();
   }, [applicationId, callId, show]);
 
   const createApplication = async () => {
@@ -152,11 +153,33 @@ export function ApplicationProvider({
     }
   };
 
+  const uploadProposal = async (file: File) => {
+    if (!applicationId) return false;
+    try {
+      await apiUploadProposal(applicationId, file);
+      return true;
+    } catch {
+      show("Failed to upload proposal");
+      return false;
+    }
+  };
+
+  const uploadCV = async (file: File) => {
+    if (!applicationId) return false;
+    try {
+      await apiUploadCV(applicationId, file);
+      return true;
+    } catch {
+      show("Failed to upload cv");
+      return false;
+    }
+  };
+
   const updateApplicationField = async (field: string, value: unknown) => {
     if (!applicationId) return;
     setApplication((prev) => ({ ...prev, [field]: value }));
     try {
-      await updateApplication(applicationId, { [field]: value });
+      await patchApplication(applicationId, { [field]: value });
     } catch {
       show("Failed to update application");
     }
@@ -173,15 +196,6 @@ export function ApplicationProvider({
     }
   };
 
-
-  const updateApplicationField = async (field: string, value: any) => {
-    if (!applicationId) return false;
-    try {
-      await patchApplication(applicationId, { [field]: value });
-      setApplication((prev) => ({ ...prev, [field]: value }));
-      return true;
-    } catch {
-      show("Failed to save application");
   const addMobilityEntry = async (data: MobilityEntryInput) => {
     if (!applicationId) return false;
     try {


### PR DESCRIPTION
## Summary
- remove duplicate `updateApplicationField`
- patch application updates instead of PUT
- expose `uploadProposal` and `uploadCV` helpers
- load attachments and mobility entries correctly

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6854815a86b8832ca5e07f882bc2ef02