### PR TITLE
Fix mobility entries iteration and cleanup

### DIFF
--- a/frontend/src/context/ApplicationProvider.tsx
+++ b/frontend/src/context/ApplicationProvider.tsx
@@ -174,14 +174,6 @@ export function ApplicationProvider({
   };
 
 
-  const updateApplicationField = async (field: string, value: any) => {
-    if (!applicationId) return false;
-    try {
-      await patchApplication(applicationId, { [field]: value });
-      setApplication((prev) => ({ ...prev, [field]: value }));
-      return true;
-    } catch {
-      show("Failed to save application");
   const addMobilityEntry = async (data: MobilityEntryInput) => {
     if (!applicationId) return false;
     try {

--- a/frontend/src/pages/calls/apply/Step6_Mobility.tsx
+++ b/frontend/src/pages/calls/apply/Step6_Mobility.tsx
@@ -32,9 +32,9 @@ export default function Step6_Mobility() {
   return (
     <div className="space-y-4">
       <h2 className="text-lg font-semibold">Mobility Entries</h2>
-      {mobilityEntries.map((entry) => (
+      {entries.map((entry, index) => (
         <div
-          key={entry.id}
+          key={entry.id ?? index}
           className="grid grid-cols-1 md:grid-cols-4 gap-4 border p-4 rounded-lg shadow-sm"
         >
           <div>
@@ -67,7 +67,7 @@ export default function Step6_Mobility() {
             />
           </div>
           <div className="col-span-1 md:col-span-4 text-right">
-            <Button variant="destructive" onClick={() => handleRemove(entry.id)}>
+            <Button variant="destructive" onClick={() => handleRemove(index)}>
               Remove
             </Button>
           </div>


### PR DESCRIPTION
## Summary
- fix mapping over mobility entries using index
- use index as React key for new entries
- remove duplicate unused function in `ApplicationProvider`

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68548163fd80832cb88dfad0ee94ebe6