### PR TITLE
Integrate academic portfolio saving

### DIFF
--- a/frontend/src/context/ApplicationProvider.tsx
+++ b/frontend/src/context/ApplicationProvider.tsx
@@ -182,6 +182,10 @@ export function ApplicationProvider({
       return true;
     } catch {
       show("Failed to save application");
+      return false;
+    }
+  };
+
   const addMobilityEntry = async (data: MobilityEntryInput) => {
     if (!applicationId) return false;
     try {

--- a/frontend/src/pages/calls/apply/Step5_AcademicPortfolio.tsx
+++ b/frontend/src/pages/calls/apply/Step5_AcademicPortfolio.tsx
@@ -2,30 +2,38 @@ import { useForm, useFieldArray } from "react-hook-form";
 import { Input } from "../../../components/ui/Input";
 import { Textarea } from "../../../components/ui/Textarea";
 import { Button } from "../../../components/ui/Button";
+import { useApplication } from "../../../context/ApplicationProvider";
+import { useToast } from "../../../context/ToastProvider";
 
 export default function Step5_AcademicPortfolio() {
+  const { application, updateApplicationField } = useApplication();
+  const { show } = useToast();
+
   const { register, control, handleSubmit } = useForm({
     defaultValues: {
-      doctoral_discipline: "",
-      doctoral_thesis_title: "",
-      doctoral_awarding_institution: "",
-      doctoral_award_date: "",
-      current_institution: "",
-      current_department: "",
-      current_institution_town: "",
-      current_institution_country: "",
-      current_phone_number: "",
-      reference_list: [{
-        name_surname: "",
-        institution: "",
-        department: "",
-        country: "",
-        position: "",
-        phone_number: "",
-        email: "",
-        reason: ""
-      }],
-    }
+      doctoral_discipline: application.doctoral_discipline || "",
+      doctoral_thesis_title: application.doctoral_thesis_title || "",
+      doctoral_awarding_institution: application.doctoral_awarding_institution || "",
+      doctoral_award_date: application.doctoral_award_date || "",
+      current_institution: application.current_institution || "",
+      current_department: application.current_department || "",
+      current_institution_town: application.current_institution_town || "",
+      current_institution_country: application.current_institution_country || "",
+      current_phone_number: application.current_phone_number || "",
+      reference_list:
+        application.reference_list || [
+          {
+            name_surname: "",
+            institution: "",
+            department: "",
+            country: "",
+            position: "",
+            phone_number: "",
+            email: "",
+            reason: "",
+          },
+        ],
+    },
   });
 
   const { fields, append, remove } = useFieldArray({
@@ -33,8 +41,9 @@ export default function Step5_AcademicPortfolio() {
     name: "reference_list"
   });
 
-  const onSubmit = (data: any) => {
-    console.log("Academic Portfolio Data:", data);
+  const onSubmit = async (data: any) => {
+    await updateApplicationField("academic_portfolio", data);
+    show("Academic portfolio saved");
   };
 
   return (


### PR DESCRIPTION
## Summary
- prefill portfolio form using existing application state
- submit portfolio data via `updateApplicationField`
- fix missing return and braces in `ApplicationProvider`

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68548166d22c832c8c2c054ac6c5be51