### PR TITLE
Fix application helpers

### DIFF
--- a/frontend/src/api/applications.ts
+++ b/frontend/src/api/applications.ts
@@ -63,13 +63,9 @@ export function updateApplication(id: string, data: Record<string, unknown>) {
   });
 }
 
-export function getApplication(id: string) {
-  return apiFetch(`/applications/${id}`) as Promise<any>;
-}
-
 export function patchApplication(id: string, data: Record<string, unknown>) {
   return apiFetch(`/applications/${id}`, {
-    method: "PUT",
+    method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
   });

--- a/frontend/src/context/ApplicationProvider.tsx
+++ b/frontend/src/context/ApplicationProvider.tsx
@@ -6,6 +6,7 @@ import {
   uploadCV as apiUploadCV,
   deleteAttachment as apiDeleteAttachment,
   updateApplication,
+  patchApplication,
   getApplication,
   getApplicationAttachments,
 } from "../api/applications";
@@ -174,14 +175,18 @@ export function ApplicationProvider({
   };
 
 
-  const updateApplicationField = async (field: string, value: any) => {
-    if (!applicationId) return false;
-    try {
-      await patchApplication(applicationId, { [field]: value });
-      setApplication((prev) => ({ ...prev, [field]: value }));
-      return true;
-    } catch {
-      show("Failed to save application");
+const updateApplicationField = async (field: string, value: any) => {
+  if (!applicationId) return false;
+  try {
+    await patchApplication(applicationId, { [field]: value });
+    setApplication((prev) => ({ ...prev, [field]: value }));
+    return true;
+  } catch {
+    show("Failed to save application");
+    return false;
+  }
+};
+
   const addMobilityEntry = async (data: MobilityEntryInput) => {
     if (!applicationId) return false;
     try {


### PR DESCRIPTION
## Summary
- dedupe `getApplication` and use PATCH for application updates
- import `patchApplication` helper in `ApplicationProvider`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68548175dcf4832c87d09b64ba99bfbc