### PR TITLE
Fix duplicate updateApplicationField function

### DIFF
--- a/frontend/src/context/ApplicationProvider.tsx
+++ b/frontend/src/context/ApplicationProvider.tsx
@@ -200,17 +200,6 @@ export function ApplicationProvider({
 
 
 
-const updateApplicationField = async (field: string, value: any) => {
-  if (!applicationId) return false;
-  try {
-    await patchApplication(applicationId, { [field]: value });
-    setApplication((prev) => ({ ...prev, [field]: value }));
-    return true;
-  } catch {
-    show("Failed to save application");
-    return false;
-  }
-};
   const addMobilityEntry = async (data: MobilityEntryInput) => {
     if (!applicationId) return false;
     try {


### PR DESCRIPTION
## Summary
- remove duplicate implementation of `updateApplicationField`

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685485ef03d4832cb13e64510442984c