### PR TITLE
Fix duplicate import bug

### DIFF
--- a/frontend/src/context/ApplicationProvider.tsx
+++ b/frontend/src/context/ApplicationProvider.tsx
@@ -9,7 +9,6 @@ import {
   patchApplication,
   getApplication,
   getApplicationAttachments,
-  patchApplication,
 } from "../api/applications";
 import {
   getMobilityEntries as apiGetMobilityEntries,


### PR DESCRIPTION
## Summary
- fix duplicate import for `patchApplication` to resolve build error

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_685486b85a08832c96f0048874beecb9