### PR TITLE
Add completed_steps support to Application

### DIFF
--- a/backend/app/models/application.py
+++ b/backend/app/models/application.py
@@ -8,6 +8,7 @@ class Application(Base, SoftDeleteMixin):
     call_id = Column(UUID(as_uuid=True), ForeignKey('calls.id', ondelete='CASCADE'))
     user_id = Column(UUID(as_uuid=True), ForeignKey('users.id'))
     status = Column(SAEnum(ApplicationStatus), default=ApplicationStatus.DRAFT)
+    completed_steps = Column(JSON, default=list)
     created_at = Column(DateTime(timezone=True), default=datetime.utcnow)
     updated_at = Column(DateTime(timezone=True), default=datetime.utcnow)
 

--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -4,6 +4,7 @@ class ApplicationBase(BaseModel):
     call_id: Optional[uuid.UUID] = None
     user_id: Optional[uuid.UUID] = None
     status: ApplicationStatus = ApplicationStatus.DRAFT
+    completed_steps: Optional[list[str]] = None
 
 
 class ApplicationCreate(ApplicationBase):


### PR DESCRIPTION
## Summary
- add `completed_steps` JSON column to Application model
- include optional `completed_steps` list in Application schemas

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_685487ce556c832cb6f7c830dbad0460