### PR TITLE
Manage completed steps in context

### DIFF
--- a/frontend/src/pages/calls/apply/ApplicationLayout.tsx
+++ b/frontend/src/pages/calls/apply/ApplicationLayout.tsx
@@ -36,8 +36,8 @@ export default function ApplicationLayout() {
 }
 
 function LayoutContent({ activeIndex }: { activeIndex: number }) {
-  const { application } = useApplication();
-  const completed = application.completed_steps || [];
+  const { completedSteps } = useApplication();
+  const completed = completedSteps;
   return (
     <div className="p-6 md:flex md:space-x-6">
       <nav className="w-full md:w-64 space-y-2 mb-4 md:mb-0" aria-label="Progress">

--- a/frontend/src/pages/calls/apply/Step1_CallInfo.tsx
+++ b/frontend/src/pages/calls/apply/Step1_CallInfo.tsx
@@ -4,7 +4,7 @@ import { useToast } from "../../../context/ToastProvider";
 import { useApplication } from "../../../context/ApplicationProvider";
 
 export default function Step1_CallInfo() {
-  const { call, createApplication, applicationId, application, updateApplicationField } = useApplication();
+  const { call, createApplication, applicationId, completeStep } = useApplication();
   const { show } = useToast();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -15,9 +15,7 @@ export default function Step1_CallInfo() {
     try {
       const id = await createApplication();
       if (id) {
-        const steps = new Set<string>(application.completed_steps || []);
-        steps.add("step1");
-        await updateApplicationField("completed_steps", Array.from(steps));
+        await completeStep("step1");
         show("Application created");
       }
     } catch (err) {

--- a/frontend/src/pages/calls/apply/Step2_ApplicantInfo.tsx
+++ b/frontend/src/pages/calls/apply/Step2_ApplicantInfo.tsx
@@ -28,7 +28,7 @@ const schema = z.object({
 
 
 export default function Step2_ApplicantInfo() {
-  const { updateApplicationField, application } = useApplication();
+  const { updateApplicationField, application, completeStep } = useApplication();
   const { show } = useToast();
   const {
     register,
@@ -57,9 +57,7 @@ export default function Step2_ApplicantInfo() {
       for (const [field, value] of Object.entries(data)) {
         await updateApplicationField(field, value);
       }
-      const steps = new Set<string>(application.completed_steps || []);
-      steps.add("step2");
-      await updateApplicationField("completed_steps", Array.from(steps));
+      await completeStep("step2");
       show("Applicant Info saved");
     } catch (error) {
       show("Failed to save applicant info");

--- a/frontend/src/pages/calls/apply/Step3_ApplicationDetails.tsx
+++ b/frontend/src/pages/calls/apply/Step3_ApplicationDetails.tsx
@@ -21,7 +21,7 @@ const schema = z.object({
 type FormValues = z.infer<typeof schema>;
 
 export default function Step3_ApplicationDetails() {
-  const { application, updateApplicationField } = useApplication();
+  const { application, updateApplicationField, completeStep } = useApplication();
   const { show } = useToast();
 
 
@@ -44,10 +44,8 @@ export default function Step3_ApplicationDetails() {
     },
   });
 
-  const onSubmit = () => {
-    const steps = new Set<string>(application.completed_steps || []);
-    steps.add("step3");
-    updateApplicationField("completed_steps", Array.from(steps));
+  const onSubmit = async () => {
+    await completeStep("step3");
     show("Application details saved");
   };
 

--- a/frontend/src/pages/calls/apply/Step4_DocumentsUpload.tsx
+++ b/frontend/src/pages/calls/apply/Step4_DocumentsUpload.tsx
@@ -5,7 +5,7 @@ import DocumentList from "../../../components/ui/DocumentList";
 
 import { FileInput } from "../../../components/ui";
 export default function Step4_DocumentsUpload() {
-  const { uploadAttachment, attachments, deleteAttachment, updateApplicationField, application } = useApplication();
+  const { uploadAttachment, attachments, deleteAttachment, completeStep } = useApplication();
   const { show } = useToast();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -20,9 +20,7 @@ export default function Step4_DocumentsUpload() {
     setError(null);
     try {
       await uploadAttachment(file, field);
-      const steps = new Set<string>(application.completed_steps || []);
-      steps.add("step4");
-      await updateApplicationField("completed_steps", Array.from(steps));
+      await completeStep("step4");
       show("File uploaded");
     } catch (err) {
       setError((err as Error).message);

--- a/frontend/src/pages/calls/apply/Step5_AcademicPortfolio.tsx
+++ b/frontend/src/pages/calls/apply/Step5_AcademicPortfolio.tsx
@@ -6,7 +6,7 @@ import { useApplication } from "../../../context/ApplicationProvider";
 import { useToast } from "../../../context/ToastProvider";
 
 export default function Step5_AcademicPortfolio() {
-  const { updateApplicationField, application } = useApplication();
+  const { updateApplicationField, application, completeStep } = useApplication();
   const { show } = useToast();
   const { register, control, handleSubmit } = useForm({
     defaultValues: {
@@ -43,9 +43,7 @@ export default function Step5_AcademicPortfolio() {
   const onSubmit = async (data: any) => {
     try {
       await updateApplicationField("academic_portfolio", data);
-      const steps = new Set<string>(application.completed_steps || []);
-      steps.add("step5");
-      await updateApplicationField("completed_steps", Array.from(steps));
+      await completeStep("step5");
       show("Academic portfolio saved");
     } catch {
       show("Failed to save portfolio");

--- a/frontend/src/pages/calls/apply/Step6_Mobility.tsx
+++ b/frontend/src/pages/calls/apply/Step6_Mobility.tsx
@@ -6,7 +6,7 @@ import { useApplication } from "../../../context/ApplicationProvider";
 import type { MobilityEntryInput, MobilityEntry } from "../../../types/mobility.types";
 
 export default function Step6_Mobility() {
-  const { updateApplicationField, application } = useApplication();
+  const { updateApplicationField, application, completeStep } = useApplication();
   const [entries, setEntries] = useState<MobilityEntry[]>(application.mobility_entries || []);
 
   const handleChange = (index: number, field: keyof MobilityEntry, value: string) => {
@@ -14,9 +14,7 @@ export default function Step6_Mobility() {
     updated[index][field] = value;
     setEntries(updated);
     updateApplicationField("mobility_entries", updated);
-    const steps = new Set<string>(application.completed_steps || []);
-    steps.add("step6");
-    updateApplicationField("completed_steps", Array.from(steps));
+    completeStep("step6");
   };
 
   const handleAdd = () => {
@@ -24,18 +22,14 @@ export default function Step6_Mobility() {
     const updated = [...entries, newEntry];
     setEntries(updated);
     updateApplicationField("mobility_entries", updated);
-    const steps = new Set<string>(application.completed_steps || []);
-    steps.add("step6");
-    updateApplicationField("completed_steps", Array.from(steps));
+    completeStep("step6");
   };
 
   const handleRemove = (index: number) => {
     const updated = entries.filter((_, i) => i !== index);
     setEntries(updated);
     updateApplicationField("mobility_entries", updated);
-    const steps = new Set<string>(application.completed_steps || []);
-    steps.add("step6");
-    updateApplicationField("completed_steps", Array.from(steps));
+    completeStep("step6");
   };
 
   return (

--- a/frontend/src/pages/calls/apply/Step7_ProposalCV.tsx
+++ b/frontend/src/pages/calls/apply/Step7_ProposalCV.tsx
@@ -5,7 +5,7 @@ import { useToast } from "../../../context/ToastProvider";
 import { FileInput } from "../../../components/ui";
 import DocumentList from "../../../components/ui/DocumentList";
 export default function Step7_ProposalCV() {
-  const { uploadProposal, uploadCV, updateApplicationField, application } = useApplication();
+  const { uploadProposal, uploadCV, attachments, deleteAttachment, completeStep } = useApplication();
 
   const { show } = useToast();
   const [loadingProposal, setLoadingProposal] = useState(false);
@@ -22,9 +22,7 @@ export default function Step7_ProposalCV() {
     setError(null);
     try {
       await uploadFunc(file);
-      const steps = new Set<string>(application.completed_steps || []);
-      steps.add("step7");
-      await updateApplicationField("completed_steps", Array.from(steps));
+      await completeStep("step7");
       show(`${type.toUpperCase()} uploaded successfully.`);
     } catch (err) {
       setError((err as Error).message);

--- a/frontend/src/pages/calls/apply/Step8_EthicsSecurity.tsx
+++ b/frontend/src/pages/calls/apply/Step8_EthicsSecurity.tsx
@@ -5,7 +5,7 @@ import EthicsIssuesTable from "../../../components/application/EthicsIssuesTable
 import SecurityIssuesTable from "../../../components/application/SecurityIssuesTable";
 
 export default function Step8_EthicsSecurity() {
-  const { application, updateApplicationField } = useApplication();
+  const { application, updateApplicationField, completeStep } = useApplication();
   const { show } = useToast();
   const [ethicsConfirmed, setEthicsConfirmed] = useState(
     application.ethics_confirmed || false
@@ -28,9 +28,7 @@ export default function Step8_EthicsSecurity() {
       "security_self_assessment_text",
       securitySelfAssessment
     );
-    const steps = new Set<string>(application.completed_steps || []);
-    steps.add("step8");
-    updateApplicationField("completed_steps", Array.from(steps));
+    completeStep("step8");
     show("Section saved");
   };
 

--- a/frontend/src/pages/calls/apply/Step9_ReviewSubmit.tsx
+++ b/frontend/src/pages/calls/apply/Step9_ReviewSubmit.tsx
@@ -4,7 +4,7 @@ import { Button } from "../../../components/ui/Button";
 import ConfirmModal from "../../../components/ui/ConfirmModal";
 
 export default function Step9_ReviewSubmit() {
-  const { applicationId, submitApplication, updateApplicationField, application } = useApplication();
+  const { applicationId, submitApplication, application, completeStep } = useApplication();
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const [open, setOpen] = useState(false);
@@ -17,9 +17,7 @@ export default function Step9_ReviewSubmit() {
       const success = await submitApplication();
       if (success) {
         setSubmitted(true);
-        const steps = new Set<string>(application.completed_steps || []);
-        steps.add("step9");
-        await updateApplicationField("completed_steps", Array.from(steps));
+        await completeStep("step9");
       } else {
         setError("Submission failed. Please try again.");
       }


### PR DESCRIPTION
## Summary
- keep completed steps in `ApplicationProvider`
- add `completeStep` helper
- show progress highlighting using new `completedSteps`
- refactor step pages to call `completeStep`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_685487cf5858832cb9af3f68952adc41