### PR TITLE
Fix attachments destructuring in proposal step

### DIFF
--- a/frontend/src/pages/calls/apply/Step7_ProposalCV.tsx
+++ b/frontend/src/pages/calls/apply/Step7_ProposalCV.tsx
@@ -5,7 +5,14 @@ import { useToast } from "../../../context/ToastProvider";
 import { FileInput } from "../../../components/ui";
 import DocumentList from "../../../components/ui/DocumentList";
 export default function Step7_ProposalCV() {
-  const { uploadProposal, uploadCV, updateApplicationField, application } = useApplication();
+  const {
+    uploadProposal,
+    uploadCV,
+    updateApplicationField,
+    application,
+    attachments,
+    deleteAttachment,
+  } = useApplication();
 
   const { show } = useToast();
   const [loadingProposal, setLoadingProposal] = useState(false);


### PR DESCRIPTION
## Summary
- include `attachments` and `deleteAttachment` from `useApplication`
- render `DocumentList` for proposal and CV uploads with those values

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685487d00238832c8ebed9d4f63cdabe