### PR TITLE
Use mobility entry context API

### DIFF
--- a/frontend/src/pages/calls/apply/Step6_Mobility.tsx
+++ b/frontend/src/pages/calls/apply/Step6_Mobility.tsx
@@ -1,38 +1,65 @@
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button, Input, DatePicker } from "../../../components/ui";
 
 import { useApplication } from "../../../context/ApplicationProvider";
 import type { MobilityEntryInput, MobilityEntry } from "../../../types/mobility.types";
 
 export default function Step6_Mobility() {
-  const { updateApplicationField, application } = useApplication();
-  const [entries, setEntries] = useState<MobilityEntry[]>(application.mobility_entries || []);
+  const {
+    addMobilityEntry,
+    updateMobilityEntry,
+    removeMobilityEntry,
+    updateApplicationField,
+    mobilityEntries,
+    application,
+  } = useApplication();
 
-  const handleChange = (index: number, field: keyof MobilityEntry, value: string) => {
+  type EntryState = MobilityEntryInput & Partial<MobilityEntry>;
+
+  const [entries, setEntries] = useState<EntryState[]>(mobilityEntries);
+
+  useEffect(() => {
+    setEntries(mobilityEntries);
+  }, [mobilityEntries]);
+
+  const handleChange = (
+    index: number,
+    field: keyof MobilityEntryInput,
+    value: string
+  ) => {
     const updated = [...entries];
-    updated[index][field] = value;
+    updated[index] = { ...updated[index], [field]: value };
     setEntries(updated);
-    updateApplicationField("mobility_entries", updated);
+
+    const entry = updated[index];
+    if (entry.id) {
+      updateMobilityEntry(entry.id, entry);
+    } else if (entry.from_date && entry.to_date) {
+      addMobilityEntry(entry as MobilityEntryInput);
+    }
+
     const steps = new Set<string>(application.completed_steps || []);
     steps.add("step6");
     updateApplicationField("completed_steps", Array.from(steps));
   };
 
   const handleAdd = () => {
-    const newEntry = { from_date: "", to_date: "", organisation: "", country: "" };
-    const updated = [...entries, newEntry];
-    setEntries(updated);
-    updateApplicationField("mobility_entries", updated);
-    const steps = new Set<string>(application.completed_steps || []);
-    steps.add("step6");
-    updateApplicationField("completed_steps", Array.from(steps));
+    const newEntry: EntryState = {
+      from_date: "",
+      to_date: "",
+      organisation: "",
+      country: "",
+    };
+    setEntries([...entries, newEntry]);
   };
 
   const handleRemove = (index: number) => {
-    const updated = entries.filter((_, i) => i !== index);
-    setEntries(updated);
-    updateApplicationField("mobility_entries", updated);
+    const entry = entries[index];
+    setEntries(entries.filter((_, i) => i !== index));
+    if (entry.id) {
+      removeMobilityEntry(entry.id);
+    }
     const steps = new Set<string>(application.completed_steps || []);
     steps.add("step6");
     updateApplicationField("completed_steps", Array.from(steps));


### PR DESCRIPTION
## Summary
- use mobility entry helpers from context for step 6
- keep step 6 UI synced with mobility entries in context

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685487d0afb8832c910ec713b484aeac