### PR TITLE
Replace console logs with API calls

### DIFF
--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -1,0 +1,29 @@
+import { apiFetch } from "../lib/api";
+import type { CreateUserInput, UpdateUserInput, User } from "../types/users.types";
+
+export function createUser(data: CreateUserInput) {
+  const payload = {
+    email: data.email,
+    first_name: data.first_name ?? "",
+    last_name: data.last_name ?? "",
+    password: data.password ?? "",
+    role: data.role,
+  };
+  return apiFetch("/users", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  }) as Promise<User>;
+}
+
+export function updateUser(id: string, data: UpdateUserInput) {
+  return apiFetch(`/users/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  }) as Promise<User>;
+}
+
+export function getUser(id: string) {
+  return apiFetch(`/users/${id}`) as Promise<User>;
+}

--- a/frontend/src/pages/AdminUserManagementPage.tsx
+++ b/frontend/src/pages/AdminUserManagementPage.tsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import { Input } from "../components/ui/Input";
 import { Button } from "../components/ui/Button";
 import { UserRole } from "../types/global";
+import { createUser } from "../api/users";
+import { useToast } from "../context/ToastProvider";
 
 interface UserItem {
   email: string;
@@ -12,12 +14,18 @@ export default function AdminUserManagementPage() {
   const [users, setUsers] = useState<UserItem[]>([]);
   const [email, setEmail] = useState("");
   const [role, setRole] = useState<UserRole>(UserRole.applicant);
+  const { show } = useToast();
 
-  const handleAdd = (e: React.FormEvent) => {
+  const handleAdd = async (e: React.FormEvent) => {
     e.preventDefault();
-    console.log("Create user", { email, role });
-    setUsers((prev) => [...prev, { email, role }]);
-    setEmail("");
+    try {
+      await createUser({ email, role });
+      setUsers((prev) => [...prev, { email, role }]);
+      setEmail("");
+      show("User created");
+    } catch (err) {
+      show((err as Error).message);
+    }
   };
 
   return (

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,20 +1,41 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Input } from "../components/ui/Input";
 import { Button } from "../components/ui/Button";
+import { getUser, updateUser } from "../api/users";
+import { useAuth } from "../context/AuthProvider";
+import { useToast } from "../context/ToastProvider";
 
 export default function SettingsPage() {
+  const { userId } = useAuth();
+  const { show } = useToast();
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
   const [institution, setInstitution] = useState("");
   const [password, setPassword] = useState("");
 
-  const handleSubmit = () => {
-    console.log("Update settings", {
-      firstName,
-      lastName,
-      institution,
-      password,
-    });
+  useEffect(() => {
+    if (!userId) return;
+    getUser(userId)
+      .then((u) => {
+        setFirstName(u.first_name);
+        setLastName(u.last_name);
+      })
+      .catch(() => {});
+  }, [userId]);
+
+  const handleSubmit = async () => {
+    if (!userId) return;
+    try {
+      await updateUser(userId, {
+        first_name: firstName,
+        last_name: lastName,
+        password: password || undefined,
+      });
+      show("Settings updated");
+      setPassword("");
+    } catch (err) {
+      show((err as Error).message);
+    }
   };
 
   return (

--- a/frontend/src/types/users.types.ts
+++ b/frontend/src/types/users.types.ts
@@ -1,0 +1,27 @@
+import { UserRole } from './global';
+
+export interface User {
+  id: string;
+  email: string;
+  first_name: string;
+  last_name: string;
+  role: UserRole;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface CreateUserInput {
+  email: string;
+  first_name?: string;
+  last_name?: string;
+  password?: string;
+  role?: UserRole;
+}
+
+export interface UpdateUserInput {
+  email?: string;
+  first_name?: string;
+  last_name?: string;
+  password?: string | null;
+  role?: UserRole;
+}


### PR DESCRIPTION
## Summary
- implement `createUser`, `updateUser`, and `getUser` API helpers
- add user type definitions
- wire AdminUserManagementPage to create users through the API
- connect SettingsPage to load/update user profile

## Testing
- `pytest -q` *(fails: No module named 'fastapi')*
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_685487d1c9b4832cb0d5cf0e0d40e842