### PR TITLE
Remove leftover schema definition

### DIFF
--- a/frontend/src/pages/calls/apply/Step2_ApplicantInfo.tsx
+++ b/frontend/src/pages/calls/apply/Step2_ApplicantInfo.tsx
@@ -1,6 +1,5 @@
 
 import { useForm } from "react-hook-form";
-import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 
 import { Input } from "../../../components/ui/Input";
@@ -11,20 +10,6 @@ import {
   type ApplicantInfoForm,
 } from "./schemas";
 
-const schema = z.object({
-  title: z.string().optional(),
-  surname: z.string().min(1, "Required"),
-  first_name: z.string().min(1, "Required"),
-  year_of_birth: z.string().optional(),
-  nationality: z.string().optional(),
-  organisation: z.string().optional(),
-  university: z.string().optional(),
-  department: z.string().optional(),
-  town_or_city: z.string().optional(),
-  country: z.string().optional(),
-  current_position: z.string().optional(),
-  gender: z.string().optional(),
-});
 
 
 export default function Step2_ApplicantInfo() {


### PR DESCRIPTION
## Summary
- clean up Step2_ApplicantInfo form by deleting unused zod schema

## Testing
- `pytest -q`
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_685488097304832c959bc2743cc72d14