### PR TITLE
Fix Step7 completeStep call

### DIFF
--- a/frontend/src/pages/calls/apply/Step7_ProposalCV.tsx
+++ b/frontend/src/pages/calls/apply/Step7_ProposalCV.tsx
@@ -12,6 +12,7 @@ export default function Step7_ProposalCV() {
     application,
     attachments,
     deleteAttachment,
+    completeStep,
   } = useApplication();
 
 


### PR DESCRIPTION
## Summary
- ensure `completeStep` is available in Step7 component

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68551e74bc74832cbd9d030ed3b1f553