### PR TITLE
Navigate to step2 after creating application

### DIFF
--- a/frontend/src/pages/calls/apply/Step1_CallInfo.tsx
+++ b/frontend/src/pages/calls/apply/Step1_CallInfo.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Button } from "../../../components/ui/Button";
 import { useToast } from "../../../context/ToastProvider";
 import { useApplication } from "../../../context/ApplicationProvider";
@@ -6,6 +7,7 @@ import { useApplication } from "../../../context/ApplicationProvider";
 export default function Step1_CallInfo() {
   const { call, createApplication, applicationId, completeStep } = useApplication();
   const { show } = useToast();
+  const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -17,6 +19,7 @@ export default function Step1_CallInfo() {
       if (id) {
         await completeStep("step1");
         show("Application created");
+        navigate("../step2");
       }
     } catch (err) {
       setError((err as Error).message);


### PR DESCRIPTION
## Summary
- route from step1 to step2 after creating an application

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68551e9d3630832c9dc43bb54c1c2fa8