### PR TITLE
Improve application step handling and UI

### DIFF
--- a/frontend/src/components/application/EthicsIssuesTable.tsx
+++ b/frontend/src/components/application/EthicsIssuesTable.tsx
@@ -12,10 +12,27 @@ export default function EthicsIssuesTable() {
     <div className="space-y-2">
       <h3 className="font-medium">Ethics Issues</h3>
       <Table>
+        <thead>
+          <tr>
+            <th>Question</th>
+            <th>Yes</th>
+            <th>No</th>
+            <th>Page</th>
+          </tr>
+        </thead>
         <tbody>
           {ethicsQuestions.map((q, i) => (
             <tr key={i}>
               <td>{q}</td>
+              <td>
+                <input type="radio" name={`ethics_${i}`} value="yes" />
+              </td>
+              <td>
+                <input type="radio" name={`ethics_${i}`} value="no" />
+              </td>
+              <td>
+                <input type="text" className="input w-20" />
+              </td>
             </tr>
           ))}
         </tbody>

--- a/frontend/src/components/application/SecurityIssuesTable.tsx
+++ b/frontend/src/components/application/SecurityIssuesTable.tsx
@@ -11,10 +11,27 @@ export default function SecurityIssuesTable() {
     <div className="space-y-2">
       <h3 className="font-medium">Security Issues</h3>
       <Table>
+        <thead>
+          <tr>
+            <th>Question</th>
+            <th>Yes</th>
+            <th>No</th>
+            <th>Page</th>
+          </tr>
+        </thead>
         <tbody>
           {securityQuestions.map((q, i) => (
             <tr key={i}>
               <td>{q}</td>
+              <td>
+                <input type="radio" name={`security_${i}`} value="yes" />
+              </td>
+              <td>
+                <input type="radio" name={`security_${i}`} value="no" />
+              </td>
+              <td>
+                <input type="text" className="input w-20" />
+              </td>
             </tr>
           ))}
         </tbody>

--- a/frontend/src/components/ui/DocumentList.tsx
+++ b/frontend/src/components/ui/DocumentList.tsx
@@ -3,6 +3,8 @@ import { useState } from "react";
 import { Attachment } from "../../types/application";
 import ConfirmModal from "./ConfirmModal";
 
+const API_BASE = import.meta.env.VITE_API_BASE || "http://localhost:8000";
+
 export default function DocumentList({
   documents,
   onDelete,
@@ -19,9 +21,13 @@ export default function DocumentList({
     <ul className="space-y-2">
       {documents.map((doc) => (
         <li key={doc.id} className="flex justify-between border p-2 rounded">
-          <span>
+          <a
+            href={`${API_BASE}/files/${doc.id}`}
+            className="text-blue-600 underline"
+            download
+          >
             {doc.field_name ? `${doc.field_name}: ${doc.doc_name}` : doc.doc_name}
-          </span>
+          </a>
           {onDelete && (
             <>
               <button

--- a/frontend/src/context/ApplicationProvider.tsx
+++ b/frontend/src/context/ApplicationProvider.tsx
@@ -30,6 +30,7 @@ interface ApplicationContextValue {
   attachments: Attachment[];
   mobilityEntries: MobilityEntry[];
   completedSteps: string[];
+  partialSteps: string[];
   createApplication: () => Promise<string | null>;
   uploadAttachment: (file: File, field: string) => Promise<boolean>;
   uploadProposal: (file: File) => Promise<boolean>;
@@ -41,6 +42,8 @@ interface ApplicationContextValue {
   submitApplication: () => Promise<boolean>;
   updateApplicationField: (field: string, value: unknown) => Promise<void>;
   completeStep: (step: string) => Promise<void>;
+  markPartialStep: (step: string) => void;
+  clearPartialStep: (step: string) => void;
 }
 
 const ApplicationContext = createContext<ApplicationContextValue>({
@@ -50,6 +53,7 @@ const ApplicationContext = createContext<ApplicationContextValue>({
   attachments: [],
   mobilityEntries: [],
   completedSteps: [],
+  partialSteps: [],
   createApplication: async () => null,
   uploadAttachment: async () => false,
   uploadProposal: async () => false,
@@ -82,6 +86,7 @@ export function ApplicationProvider({
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [mobilityEntries, setMobilityEntries] = useState<MobilityEntry[]>([]);
   const [completedSteps, setCompletedSteps] = useState<string[]>([]);
+  const [partialSteps, setPartialSteps] = useState<string[]>([]);
   const { show } = useToast();
 
   useEffect(() => {
@@ -203,6 +208,15 @@ export function ApplicationProvider({
     const newList = Array.from(steps);
     setCompletedSteps(newList);
     await updateApplicationField("completed_steps", newList);
+    setPartialSteps((prev) => prev.filter((s) => s !== step));
+  };
+
+  const markPartialStep = (step: string) => {
+    setPartialSteps((prev) => (prev.includes(step) ? prev : [...prev, step]));
+  };
+
+  const clearPartialStep = (step: string) => {
+    setPartialSteps((prev) => prev.filter((s) => s !== step));
   };
 
   const deleteAttachment = async (id: string) => {
@@ -275,6 +289,7 @@ export function ApplicationProvider({
         attachments,
         mobilityEntries,
         completedSteps,
+        partialSteps,
         createApplication,
         uploadAttachment,
         uploadProposal,
@@ -286,6 +301,8 @@ export function ApplicationProvider({
         submitApplication,
         updateApplicationField,
         completeStep,
+        markPartialStep,
+        clearPartialStep,
       }}
     >
       {children}

--- a/frontend/src/pages/calls/apply/ApplicationLayout.tsx
+++ b/frontend/src/pages/calls/apply/ApplicationLayout.tsx
@@ -36,7 +36,7 @@ export default function ApplicationLayout() {
 }
 
 function LayoutContent({ activeIndex }: { activeIndex: number }) {
-  const { completedSteps } = useApplication();
+  const { completedSteps, partialSteps } = useApplication();
   const completed = completedSteps;
   return (
     <div className="p-6 md:flex md:space-x-6">
@@ -47,18 +47,23 @@ function LayoutContent({ activeIndex }: { activeIndex: number }) {
             to={step.path}
             className={({ isActive }) => {
               const isCompleted = completed.includes(step.path);
+              const isPartial = partialSteps.includes(step.path) && !isCompleted;
               return [
                 "block px-4 py-2 rounded-lg font-medium text-sm transition",
                 isActive || index === activeIndex
                   ? "bg-blue-600 text-white"
                   : isCompleted
                   ? "bg-green-200 text-gray-700 hover:bg-green-300"
+                  : isPartial
+                  ? "bg-yellow-200 text-gray-700 hover:bg-yellow-300"
                   : "bg-gray-100 text-gray-700 hover:bg-gray-200",
               ].join(" ");
             }}
           >
             {completed.includes(step.path) ? (
               <span className="text-green-600 mr-1">✓</span>
+            ) : partialSteps.includes(step.path) ? (
+              <span className="text-yellow-600 mr-1">~</span>
             ) : (
               <span className="mr-1">{index + 1}.</span>
             )}

--- a/frontend/src/pages/calls/apply/Step1_CallInfo.tsx
+++ b/frontend/src/pages/calls/apply/Step1_CallInfo.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "../../../components/ui/Button";
 import { useToast } from "../../../context/ToastProvider";
@@ -10,6 +10,12 @@ export default function Step1_CallInfo() {
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (applicationId) {
+      completeStep("step1");
+    }
+  }, [applicationId, completeStep]);
 
   const handleCreate = async () => {
     setLoading(true);

--- a/frontend/src/pages/calls/apply/Step2_ApplicantInfo.tsx
+++ b/frontend/src/pages/calls/apply/Step2_ApplicantInfo.tsx
@@ -23,37 +23,11 @@ export default function Step2_ApplicantInfo() {
     formState: { errors, isSubmitting },
   } = useForm<ApplicantInfoForm>({
     resolver: zodResolver(applicantInfoSchema),
-    defaultValues: {
-      title: application.title || "",
-      surname: application.surname || "",
-      first_name: application.first_name || "",
-      year_of_birth: application.year_of_birth || "",
-      nationality: application.nationality || "",
-      organisation: application.organisation || "",
-      university: application.university || "",
-      department: application.department || "",
-      town_or_city: application.town_or_city || "",
-      country: application.country || "",
-      current_position: application.current_position || "",
-      gender: application.gender || "",
-    },
+    defaultValues: {},
   });
 
   useEffect(() => {
-    reset({
-      title: application.title || "",
-      surname: application.surname || "",
-      first_name: application.first_name || "",
-      year_of_birth: application.year_of_birth || "",
-      nationality: application.nationality || "",
-      organisation: application.organisation || "",
-      university: application.university || "",
-      department: application.department || "",
-      town_or_city: application.town_or_city || "",
-      country: application.country || "",
-      current_position: application.current_position || "",
-      gender: application.gender || "",
-    });
+    reset(application as Partial<ApplicantInfoForm>);
   }, [application, reset]);
 
   const onSubmit = async (data: ApplicantInfoForm) => {

--- a/frontend/src/pages/calls/apply/Step3_ApplicationDetails.tsx
+++ b/frontend/src/pages/calls/apply/Step3_ApplicationDetails.tsx
@@ -34,29 +34,11 @@ export default function Step3_ApplicationDetails() {
     formState: { errors },
   } = useForm<FormValues>({
     resolver: zodResolver(schema),
-    defaultValues: {
-      project_title: application.project_title || "",
-      acronym: application.acronym || "",
-      keywords: application.keywords || "",
-      abstract: application.abstract || "",
-      selected_supervisor: application.selected_supervisor || "",
-      has_secondment: application.has_secondment || false,
-      selected_from_db: application.selected_from_db || false,
-      institution_name: application.institution_name || "",
-    },
+    defaultValues: {},
   });
 
   useEffect(() => {
-    reset({
-      project_title: application.project_title || "",
-      acronym: application.acronym || "",
-      keywords: application.keywords || "",
-      abstract: application.abstract || "",
-      selected_supervisor: application.selected_supervisor || "",
-      has_secondment: application.has_secondment || false,
-      selected_from_db: application.selected_from_db || false,
-      institution_name: application.institution_name || "",
-    });
+    reset(application as Partial<FormValues>);
   }, [application, reset]);
 
   const onSubmit = async () => {

--- a/frontend/src/pages/calls/apply/Step4_DocumentsUpload.tsx
+++ b/frontend/src/pages/calls/apply/Step4_DocumentsUpload.tsx
@@ -5,12 +5,29 @@ import DocumentList from "../../../components/ui/DocumentList";
 
 import { FileInput } from "../../../components/ui";
 export default function Step4_DocumentsUpload() {
-  const { uploadAttachment, attachments, deleteAttachment, completeStep } = useApplication();
+  const {
+    uploadAttachment,
+    attachments,
+    deleteAttachment,
+    completeStep,
+    markPartialStep,
+    clearPartialStep,
+  } = useApplication();
   const { show } = useToast();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [passportUploaded, setPassportUploaded] = useState(false);
   const [phdCertificateUploaded, setPhdCertificateUploaded] = useState(false);
+
+  const handleSave = async () => {
+    if (passportUploaded && phdCertificateUploaded) {
+      await completeStep("step4");
+      show("Documents saved");
+    } else {
+      markPartialStep("step4");
+      show("Please upload both documents before completing this step");
+    }
+  };
 
   useEffect(() => {
     const hasPassport = attachments.some((a) => a.field_name === "passport_or_id");
@@ -18,9 +35,13 @@ export default function Step4_DocumentsUpload() {
     setPassportUploaded(hasPassport);
     setPhdCertificateUploaded(hasPhd);
     if (hasPassport && hasPhd) {
-      completeStep("step4");
+      clearPartialStep("step4");
+    } else if (hasPassport || hasPhd) {
+      markPartialStep("step4");
+    } else {
+      clearPartialStep("step4");
     }
-  }, [attachments, completeStep]);
+  }, [attachments, markPartialStep, clearPartialStep]);
 
   const handleChange = async (
     e: ChangeEvent<HTMLInputElement>,
@@ -75,6 +96,12 @@ export default function Step4_DocumentsUpload() {
       </div>
 
       {error && <div className="text-red-500">Error: {error}</div>}
+      <button
+        onClick={handleSave}
+        className="bg-blue-600 text-white px-4 py-2 rounded"
+      >
+        Save
+      </button>
     </div>
   );
 }

--- a/frontend/src/pages/calls/apply/Step5_AcademicPortfolio.tsx
+++ b/frontend/src/pages/calls/apply/Step5_AcademicPortfolio.tsx
@@ -10,57 +10,11 @@ export default function Step5_AcademicPortfolio() {
   const { updateApplicationField, application, completeStep } = useApplication();
   const { show } = useToast();
   const { register, control, handleSubmit, reset } = useForm({
-    defaultValues: {
-      doctoral_discipline: application.doctoral_discipline || "",
-      doctoral_thesis_title: application.doctoral_thesis_title || "",
-      doctoral_awarding_institution: application.doctoral_awarding_institution || "",
-      doctoral_award_date: application.doctoral_award_date || "",
-      current_institution: application.current_institution || "",
-      current_department: application.current_department || "",
-      current_institution_town: application.current_institution_town || "",
-      current_institution_country: application.current_institution_country || "",
-      current_phone_number: application.current_phone_number || "",
-      reference_list:
-        application.reference_list || [
-          {
-            name_surname: "",
-            institution: "",
-            department: "",
-            country: "",
-            position: "",
-            phone_number: "",
-            email: "",
-            reason: "",
-          },
-        ],
-    },
+    defaultValues: {},
   });
 
   useEffect(() => {
-    reset({
-      doctoral_discipline: application.doctoral_discipline || "",
-      doctoral_thesis_title: application.doctoral_thesis_title || "",
-      doctoral_awarding_institution: application.doctoral_awarding_institution || "",
-      doctoral_award_date: application.doctoral_award_date || "",
-      current_institution: application.current_institution || "",
-      current_department: application.current_department || "",
-      current_institution_town: application.current_institution_town || "",
-      current_institution_country: application.current_institution_country || "",
-      current_phone_number: application.current_phone_number || "",
-      reference_list:
-        application.reference_list || [
-          {
-            name_surname: "",
-            institution: "",
-            department: "",
-            country: "",
-            position: "",
-            phone_number: "",
-            email: "",
-            reason: "",
-          },
-        ],
-    });
+    reset(application as any);
   }, [application, reset]);
 
   const { fields, append, remove } = useFieldArray({
@@ -81,28 +35,79 @@ export default function Step5_AcademicPortfolio() {
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
       <h2 className="text-lg font-semibold">Academic Portfolio</h2>
-      <Input label="Doctoral Discipline" {...register("doctoral_discipline")} />
-      <Input label="Doctoral Thesis Title" {...register("doctoral_thesis_title")} />
-      <Input label="Awarding Institution" {...register("doctoral_awarding_institution")} />
-      <Input label="Doctoral Award Date" type="date" {...register("doctoral_award_date")} />
-      <Input label="Current Institution" {...register("current_institution")} />
-      <Input label="Department" {...register("current_department")} />
-      <Input label="Town/City" {...register("current_institution_town")} />
-      <Input label="Country" {...register("current_institution_country")} />
-      <Input label="Phone Number" {...register("current_phone_number")} />
+      <div>
+        <label className="block text-sm">Doctoral Discipline</label>
+        <Input {...register("doctoral_discipline")} />
+      </div>
+      <div>
+        <label className="block text-sm">Doctoral Thesis Title</label>
+        <Input {...register("doctoral_thesis_title")} />
+      </div>
+      <div>
+        <label className="block text-sm">Awarding Institution</label>
+        <Input {...register("doctoral_awarding_institution")} />
+      </div>
+      <div>
+        <label className="block text-sm">Doctoral Award Date</label>
+        <Input type="date" {...register("doctoral_award_date")} />
+      </div>
+      <div>
+        <label className="block text-sm">Current Institution</label>
+        <Input {...register("current_institution")} />
+      </div>
+      <div>
+        <label className="block text-sm">Department</label>
+        <Input {...register("current_department")} />
+      </div>
+      <div>
+        <label className="block text-sm">Town/City</label>
+        <Input {...register("current_institution_town")} />
+      </div>
+      <div>
+        <label className="block text-sm">Country</label>
+        <Input {...register("current_institution_country")} />
+      </div>
+      <div>
+        <label className="block text-sm">Phone Number</label>
+        <Input {...register("current_phone_number")} />
+      </div>
 
       <div className="pt-4">
         <h3 className="font-medium">Suggested References</h3>
         {fields.map((field, index) => (
           <div key={field.id} className="border p-4 rounded mb-4 space-y-2">
-            <Input label="Full Name" {...register(`reference_list.${index}.name_surname`)} />
-            <Input label="Institution" {...register(`reference_list.${index}.institution`)} />
-            <Input label="Department" {...register(`reference_list.${index}.department`)} />
-            <Input label="Country" {...register(`reference_list.${index}.country`)} />
-            <Input label="Position" {...register(`reference_list.${index}.position`)} />
-            <Input label="Phone Number" {...register(`reference_list.${index}.phone_number`)} />
-            <Input label="Email" {...register(`reference_list.${index}.email`)} />
-            <Textarea label="Reason for Reference" {...register(`reference_list.${index}.reason`)} />
+            <div>
+              <label className="block text-sm">Full Name</label>
+              <Input {...register(`reference_list.${index}.name_surname`)} />
+            </div>
+            <div>
+              <label className="block text-sm">Institution</label>
+              <Input {...register(`reference_list.${index}.institution`)} />
+            </div>
+            <div>
+              <label className="block text-sm">Department</label>
+              <Input {...register(`reference_list.${index}.department`)} />
+            </div>
+            <div>
+              <label className="block text-sm">Country</label>
+              <Input {...register(`reference_list.${index}.country`)} />
+            </div>
+            <div>
+              <label className="block text-sm">Position</label>
+              <Input {...register(`reference_list.${index}.position`)} />
+            </div>
+            <div>
+              <label className="block text-sm">Phone Number</label>
+              <Input {...register(`reference_list.${index}.phone_number`)} />
+            </div>
+            <div>
+              <label className="block text-sm">Email</label>
+              <Input {...register(`reference_list.${index}.email`)} />
+            </div>
+            <div>
+              <label className="block text-sm">Reason for Reference</label>
+              <Textarea {...register(`reference_list.${index}.reason`)} />
+            </div>
             <Button type="button" onClick={() => remove(index)} variant="outline">Remove</Button>
           </div>
         ))}

--- a/frontend/src/pages/calls/apply/Step6_Mobility.tsx
+++ b/frontend/src/pages/calls/apply/Step6_Mobility.tsx
@@ -10,9 +10,8 @@ export default function Step6_Mobility() {
     addMobilityEntry,
     updateMobilityEntry,
     removeMobilityEntry,
-    updateApplicationField,
     mobilityEntries,
-    application,
+    completeStep,
   } = useApplication();
 
 
@@ -40,9 +39,6 @@ export default function Step6_Mobility() {
       addMobilityEntry(entry as MobilityEntryInput);
     }
 
-    const steps = new Set<string>(application.completed_steps || []);
-    steps.add("step6");
-    updateApplicationField("completed_steps", Array.from(steps));
   };
 
   const handleAdd = () => {
@@ -61,9 +57,10 @@ export default function Step6_Mobility() {
     if (entry.id) {
       removeMobilityEntry(entry.id);
     }
-    const steps = new Set<string>(application.completed_steps || []);
-    steps.add("step6");
-    updateApplicationField("completed_steps", Array.from(steps));
+  };
+
+  const handleSave = async () => {
+    await completeStep("step6");
   };
 
   return (
@@ -110,7 +107,10 @@ export default function Step6_Mobility() {
           </div>
         </div>
       ))}
-      <Button onClick={handleAdd}>Add Mobility Entry</Button>
+      <div className="space-x-2">
+        <Button onClick={handleAdd}>Add Mobility Entry</Button>
+        <Button onClick={handleSave}>Save All</Button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- update Call Info step to auto-complete when application already exists
- add partial/complete state tracking in `ApplicationProvider`
- enhance sidebar feedback for completed and partial steps
- show document download links and add Save buttons for uploads
- restructure mobility step with explicit Save All
- label academic portfolio fields
- improve upload step with save check
- redesign ethics and security tables
- reset forms when application data loads

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68552283a818832ca9ad7022963c5be4