### PR TITLE
Add field name tracking for uploaded files

### DIFF
--- a/backend/app/models/attachment.py
+++ b/backend/app/models/attachment.py
@@ -5,6 +5,7 @@ class Attachment(Base, SoftDeleteMixin):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     application_id = Column(UUID(as_uuid=True), ForeignKey('applications.id', ondelete='CASCADE'))
     doc_name = Column(String(255))
+    field_name = Column(String(255))
     file_path = Column(Text)
     file_blob = Column(LargeBinary)
     confirmed = Column(Boolean, default=False)

--- a/backend/app/schemas/attachment.py
+++ b/backend/app/schemas/attachment.py
@@ -3,6 +3,7 @@ from .base import *
 class AttachmentBase(BaseModel):
     application_id: Optional[uuid.UUID] = None
     doc_name: Optional[str] = None
+    field_name: Optional[str] = None
     file_path: Optional[str] = None
     confirmed: Optional[bool] = False
 

--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -21,7 +21,10 @@ def validate_mime_type(upload_file: UploadFile) -> None:
 
 
 def save_attachment_file(
-    db: Session, application_id: uuid.UUID, upload_file: UploadFile
+    db: Session,
+    application_id: uuid.UUID,
+    upload_file: UploadFile,
+    field_name: str | None = None,
 ):
     """Create an Attachment and store the binary data."""
     validate_mime_type(upload_file)
@@ -29,6 +32,7 @@ def save_attachment_file(
         "application_id": application_id,
         "doc_name": upload_file.filename,
         "file_path": upload_file.filename,
+        "field_name": field_name,
     }
     attachment = crud.attachment.create(db, data)
     attachment.file_blob = upload_file.file.read()

--- a/frontend/src/api/applications.ts
+++ b/frontend/src/api/applications.ts
@@ -26,21 +26,11 @@ export function uploadAttachment(applicationId: string, file: File, field: strin
 }
 
 export function uploadProposal(applicationId: string, file: File) {
-  const formData = new FormData();
-  formData.append("proposal", file);
-  return apiFetch(`/applications/${applicationId}/upload_file`, {
-    method: "POST",
-    body: formData,
-  }) as Promise<UploadAttachmentResponse>;
+  return uploadAttachment(applicationId, file, "proposal");
 }
 
 export function uploadCV(applicationId: string, file: File) {
-  const formData = new FormData();
-  formData.append("cv", file);
-  return apiFetch(`/applications/${applicationId}/upload_file`, {
-    method: "POST",
-    body: formData,
-  }) as Promise<UploadAttachmentResponse>;
+  return uploadAttachment(applicationId, file, "cv");
 }
 
 export function getApplications() {

--- a/frontend/src/types/reviews.types.ts
+++ b/frontend/src/types/reviews.types.ts
@@ -2,6 +2,7 @@
 export interface Attachment {
   id: string;
   doc_name: string;
+  field_name?: string;
   application_id?: string;
   file_path?: string;
   confirmed?: boolean;


### PR DESCRIPTION
## Summary
- store `field_name` for attachments
- expose `field_name` in attachment schema
- support optional form field in file upload route
- adapt file service to persist `field_name`
- send field name from frontend API helpers
- include `field_name` in review attachment types

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6855295c2d04832c96facd1c2296ec11