### PR TITLE
Use application_form_id for mobility entries

### DIFF
--- a/frontend/src/types/applications.types.ts
+++ b/frontend/src/types/applications.types.ts
@@ -4,6 +4,7 @@ export interface CreateApplicationRequest {
 
 export interface CreateApplicationResponse {
   id: string;
+  application_form_id?: string;
 }
 
 export interface UploadAttachmentResponse {


### PR DESCRIPTION
## Summary
- track `application_form_id` in ApplicationProvider
- fetch and create mobility entries using `application_form_id`
- expose form ID in context
- extend CreateApplicationResponse type

## Testing
- `npm run build` *(fails: Cannot find type definition file)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68552960881c832cad839aa14d388ae0