### PR TITLE
Add completed_steps to application model

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ This repository contains a simple FastAPI application for managing academic proj
      `postgresql://postgres:postgres@db:5432/project_call`.
    - `SECRET_KEY` – application secret
 
+### Database setup
+
+This project does not use migrations. Ensure the database schema matches the
+SQLAlchemy models before starting the app. You can create the initial tables
+with:
+
+```bash
+python -c "from app.database import init_db; init_db()"  # run from the backend directory
+```
+
 ## Running the app
 
 From the `backend` directory run:

--- a/backend/README.md
+++ b/backend/README.md
@@ -5,7 +5,9 @@ süreçlerini yönetmek için başlangıç bir iskelet sunar.
 
 ## Database Initialization
 
-İlk kez çalıştırmadan önce veritabanı tablolarını oluşturmanız gerekir.
+İlk kez çalıştırmadan önce veritabanı tablolarını oluşturmanız gerekir. Bu
+projede göç (migration) aracı kullanılmaz. Modellerde yapılan değişiklikler
+veritabanına elle uygulanmalıdır.
 
 ```bash
 python -c "from app.database import init_db; init_db()"

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -17,7 +17,11 @@ def get_db():
 
 
 def init_db() -> None:
-    """Create all tables in the database."""
+    """Create all tables in the database.
+
+    This project does not use migrations. When models change the tables must be
+    updated manually to match the definitions here before calling this function.
+    """
     Base.metadata.create_all(bind=engine)
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,6 +19,8 @@ app.include_router(api_router)
 
 @app.on_event("startup")
 def on_startup() -> None:
+    # Ensure tables exist before the application starts. The project does not
+    # use a migration tool so database schemas must be kept in sync manually.
     init_db()
 
 @app.get("/")

--- a/backend/app/routes/application.py
+++ b/backend/app/routes/application.py
@@ -60,6 +60,9 @@ def update_application(
         raise HTTPException(status_code=403, detail="Forbidden")
     data_dict = data.dict(exclude={"user_id"})
     data_dict["user_id"] = current_user.id
+    if data_dict.get("completed_steps") is None:
+        # Preserve existing completed steps if client omits the field
+        data_dict["completed_steps"] = obj.completed_steps
     return crud.update(db, obj, data_dict)
 
 

--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -4,7 +4,7 @@ class ApplicationBase(BaseModel):
     call_id: Optional[uuid.UUID] = None
     user_id: Optional[uuid.UUID] = None
     status: ApplicationStatus = ApplicationStatus.DRAFT
-    completed_steps: Optional[list[str]] = None
+    completed_steps: Optional[list[str]] = []
 
 
 class ApplicationCreate(ApplicationBase):


### PR DESCRIPTION
## Summary
- handle `completed_steps` updates via PUT
- expose completed steps in API schemas
- mention manual DB sync in docs and startup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68552be7bf50832cb67374856dde9e4e