### PR TITLE
Update CallPage to show admin links

### DIFF
--- a/frontend/src/pages/CallPage.tsx
+++ b/frontend/src/pages/CallPage.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { useToast } from "../context/ToastProvider";
 import { useAuth } from "../context/AuthProvider";
 import { getCalls } from "../api/calls";
+import { UserRole } from "../types/global";
 import type { Call } from "../types/global";
 
 export default function CallPage() {
@@ -57,9 +58,9 @@ export default function CallPage() {
             </Link>
           )}
 
-          {role === "admin" && (
+          {(role === UserRole.admin || role === UserRole.super_admin) && (
             <Link
-              to={`/calls/${call.id}/applications`}
+              to={`/call/${call.id}/applications`}
               className="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded"
             >
               View Applications


### PR DESCRIPTION
## Summary
- link to call applications uses `/call/${call.id}/applications`
- show link for admins and super admins
- import `UserRole` for role checks

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_685533ce0078832c85043bc0e3acff5e