### PR TITLE
Filter applications by call

### DIFF
--- a/backend/app/routes/application.py
+++ b/backend/app/routes/application.py
@@ -47,7 +47,12 @@ def read_application(obj_id: uuid.UUID, db: Session = Depends(get_db)):
     return obj
 
 @router.get('/', response_model=list[ApplicationRead])
-def read_applications(db: Session = Depends(get_db)):
+def read_applications(
+    call_id: uuid.UUID | None = None,
+    db: Session = Depends(get_db),
+):
+    if call_id is not None:
+        return list(crud.get_applications_by_call_id(db, str(call_id)))
     return list(crud.get_all(db))
 
 

--- a/frontend/src/api/applications.ts
+++ b/frontend/src/api/applications.ts
@@ -38,6 +38,11 @@ export function getApplications() {
   return apiFetch(`/applications`) as Promise<any[]>;
 }
 
+export function getApplicationsByCall(callId: string) {
+  const query = `?call_id=${encodeURIComponent(callId)}`;
+  return apiFetch(`/applications${query}`) as Promise<any[]>;
+}
+
 export function getApplication(id: string) {
   return apiFetch(`/applications/${id}`) as Promise<any>;
 }

--- a/frontend/src/pages/CallApplicationsPage.tsx
+++ b/frontend/src/pages/CallApplicationsPage.tsx
@@ -1,21 +1,24 @@
 import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
 import { useToast } from "../context/ToastProvider";
-import { getApplications } from "../api/applications";
+import { getApplicationsByCall } from "../api/applications";
 
 interface Application {
   id: string;
 }
 
 export default function CallApplicationsPage() {
+  const { callId } = useParams<{ callId: string }>();
   const { show } = useToast();
   const [apps, setApps] = useState<Application[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!callId) return;
     setLoading(true);
     setError(null);
-    getApplications()
+    getApplicationsByCall(callId)
       .then((data) => {
         setApps(data);
         if (data.length > 0) {
@@ -29,7 +32,7 @@ export default function CallApplicationsPage() {
         show("Failed to load applications");
       })
       .finally(() => setLoading(false));
-  }, [show]);
+  }, [callId, show]);
 
   return (
     <section className="w-full bg-white py-12 px-6">


### PR DESCRIPTION
## Summary
- filter applications by call ID on the backend
- add optional call_id filter API helper
- load applications for a specific call in `CallApplicationsPage`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm run build` *(fails: cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_685533cf7e3c832cbf011c7e56781c21