### PR TITLE
Restrict delete button in call management

### DIFF
--- a/frontend/src/pages/CallManagementPage.tsx
+++ b/frontend/src/pages/CallManagementPage.tsx
@@ -4,13 +4,15 @@ import { Button } from "../components/ui/Button";
 import Table from "../components/ui/Table";
 import ConfirmModal from "../components/ui/ConfirmModal";
 import { getCalls, deleteCall } from "../api/calls";
-import { Call } from "../types/global";
+import { Call, UserRole } from "../types/global";
+import { useAuth } from "../context/AuthProvider";
 
 export default function CallManagementPage() {
   const [calls, setCalls] = useState<Call[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [confirmId, setConfirmId] = useState<string | null>(null);
+  const { role } = useAuth();
   const navigate = useNavigate();
 
   async function load() {
@@ -73,16 +75,27 @@ export default function CallManagementPage() {
                 <Button type="button" onClick={() => navigate(`/call/manage/${c.id}`)}>
                   Edit
                 </Button>
-                <Button type="button" onClick={() => setConfirmId(c.id)}>
-                  Delete
-                </Button>
-                <ConfirmModal
-                  open={confirmId === c.id}
-                  onOpenChange={() => setConfirmId(null)}
-                  title="Delete call?"
-                  description="This action cannot be undone."
-                  onConfirm={() => remove(c.id)}
-                />
+                {role === UserRole.super_admin ? (
+                  <>
+                    <Button type="button" onClick={() => setConfirmId(c.id)}>
+                      Delete
+                    </Button>
+                    <ConfirmModal
+                      open={confirmId === c.id}
+                      onOpenChange={() => setConfirmId(null)}
+                      title="Delete call?"
+                      description="This action cannot be undone."
+                      onConfirm={() => remove(c.id)}
+                    />
+                  </>
+                ) : (
+                  <span
+                    className="text-gray-400"
+                    title="Only super admins can delete calls"
+                  >
+                    Delete
+                  </span>
+                )}
               </td>
               <td>
                 <Link to={`/call/${c.id}/applications`}>


### PR DESCRIPTION
## Summary
- show delete option only for `UserRole.super_admin`
- explain permissions with a tooltip

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'vite/client')*
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_685533d38ecc832cb1249814e8d111df