### PR TITLE
Lock submitted applications

### DIFF
--- a/frontend/src/context/ApplicationProvider.tsx
+++ b/frontend/src/context/ApplicationProvider.tsx
@@ -45,6 +45,7 @@ interface ApplicationContextValue {
   completeStep: (step: string) => Promise<void>;
   markPartialStep: (step: string) => void;
   clearPartialStep: (step: string) => void;
+  isSubmitted: boolean;
 }
 
 const ApplicationContext = createContext<ApplicationContextValue>({
@@ -67,6 +68,7 @@ const ApplicationContext = createContext<ApplicationContextValue>({
   submitApplication: async () => false,
   updateApplicationField: async () => {},
   completeStep: async () => {},
+  isSubmitted: false,
 });
 
 export function useApplication() {
@@ -91,6 +93,7 @@ export function ApplicationProvider({
   const [completedSteps, setCompletedSteps] = useState<string[]>([]);
   const [partialSteps, setPartialSteps] = useState<string[]>([]);
   const { show } = useToast();
+  const isSubmitted = application.status === "SUBMITTED";
 
   useEffect(() => {
     if (!callId) return;
@@ -281,6 +284,7 @@ export function ApplicationProvider({
         call_id: callId,
         status: "SUBMITTED",
       });
+      setApplication((prev) => ({ ...prev, status: "SUBMITTED" }));
       return true;
     } catch {
       show("Failed to submit application");
@@ -312,6 +316,7 @@ export function ApplicationProvider({
         completeStep,
         markPartialStep,
         clearPartialStep,
+        isSubmitted,
       }}
     >
       {children}

--- a/frontend/src/pages/calls/apply/Step2_ApplicantInfo.tsx
+++ b/frontend/src/pages/calls/apply/Step2_ApplicantInfo.tsx
@@ -14,7 +14,7 @@ import {
 
 
 export default function Step2_ApplicantInfo() {
-  const { updateApplicationField, application, completeStep } = useApplication();
+  const { updateApplicationField, application, completeStep, isSubmitted } = useApplication();
   const { show } = useToast();
   const {
     register,
@@ -47,51 +47,51 @@ export default function Step2_ApplicantInfo() {
       <h2 className="text-lg font-semibold">Applicant Info</h2>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
-          <Input {...register("title") } placeholder="Title" />
+          <Input {...register("title") } placeholder="Title" disabled={isSubmitted} />
           {errors.title && <p className="text-red-500 text-sm">{errors.title.message}</p>}
         </div>
         <div>
-          <Input {...register("surname") } placeholder="Surname" />
+          <Input {...register("surname") } placeholder="Surname" disabled={isSubmitted} />
           {errors.surname && <p className="text-red-500 text-sm">{errors.surname.message}</p>}
         </div>
         <div>
-          <Input {...register("first_name") } placeholder="First Name" />
+          <Input {...register("first_name") } placeholder="First Name" disabled={isSubmitted} />
           {errors.first_name && <p className="text-red-500 text-sm">{errors.first_name.message}</p>}
         </div>
         <div>
-          <Input {...register("year_of_birth") } placeholder="Year of Birth" />
+          <Input {...register("year_of_birth") } placeholder="Year of Birth" disabled={isSubmitted} />
           {errors.year_of_birth && <p className="text-red-500 text-sm">{errors.year_of_birth.message}</p>}
         </div>
         <div>
-          <Input {...register("nationality") } placeholder="Nationality" />
+          <Input {...register("nationality") } placeholder="Nationality" disabled={isSubmitted} />
           {errors.nationality && <p className="text-red-500 text-sm">{errors.nationality.message}</p>}
         </div>
         <div>
-          <Input {...register("organisation") } placeholder="Organisation" />
+          <Input {...register("organisation") } placeholder="Organisation" disabled={isSubmitted} />
         </div>
         <div>
-          <Input {...register("university") } placeholder="University" />
+          <Input {...register("university") } placeholder="University" disabled={isSubmitted} />
         </div>
         <div>
-          <Input {...register("department") } placeholder="Department" />
+          <Input {...register("department") } placeholder="Department" disabled={isSubmitted} />
         </div>
         <div>
-          <Input {...register("town_or_city") } placeholder="Town or City" />
+          <Input {...register("town_or_city") } placeholder="Town or City" disabled={isSubmitted} />
         </div>
         <div>
-          <Input {...register("country") } placeholder="Country" />
+          <Input {...register("country") } placeholder="Country" disabled={isSubmitted} />
           {errors.country && <p className="text-red-500 text-sm">{errors.country.message}</p>}
         </div>
         <div>
-          <Input {...register("current_position") } placeholder="Current Position" />
+          <Input {...register("current_position") } placeholder="Current Position" disabled={isSubmitted} />
         </div>
         <div>
-          <Input {...register("gender") } placeholder="Gender" />
+          <Input {...register("gender") } placeholder="Gender" disabled={isSubmitted} />
         </div>
       </div>
       <button
         type="submit"
-        disabled={isSubmitting}
+        disabled={isSubmitting || isSubmitted}
         className="mt-4 bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
       >
         Save

--- a/frontend/src/pages/calls/apply/Step3_ApplicationDetails.tsx
+++ b/frontend/src/pages/calls/apply/Step3_ApplicationDetails.tsx
@@ -22,7 +22,7 @@ const schema = z.object({
 type FormValues = z.infer<typeof schema>;
 
 export default function Step3_ApplicationDetails() {
-  const { application, updateApplicationField, completeStep } = useApplication();
+  const { application, updateApplicationField, completeStep, isSubmitted } = useApplication();
   const { show } = useToast();
 
 
@@ -49,11 +49,13 @@ export default function Step3_ApplicationDetails() {
   const reg = (name: keyof FormValues) =>
     register(name, {
       onBlur: (e) => {
+        if (isSubmitted) return;
         const value =
           e.target.type === "checkbox" ? (e.target as HTMLInputElement).checked : e.target.value;
         updateApplicationField(name, value);
       },
       onChange: (e) => {
+        if (isSubmitted) return;
         if (e.target.type === "checkbox") {
           updateApplicationField(name, (e.target as HTMLInputElement).checked);
         }
@@ -68,49 +70,49 @@ export default function Step3_ApplicationDetails() {
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
           <label className="block text-sm">Project Title</label>
-          <Input {...reg("project_title")}/>
+          <Input {...reg("project_title")} disabled={isSubmitted}/>
           {errors.project_title && (
             <p className="text-red-500 text-sm">{errors.project_title.message}</p>
           )}
         </div>
         <div>
           <label className="block text-sm">Acronym</label>
-          <Input {...reg("acronym")}/>
+          <Input {...reg("acronym")} disabled={isSubmitted}/>
         </div>
         <div>
           <label className="block text-sm">Keywords (semicolon separated)</label>
-          <Input {...reg("keywords")}/>
+          <Input {...reg("keywords")} disabled={isSubmitted}/>
         </div>
         <div>
           <label className="block text-sm">Selected Supervisor</label>
-          <Input {...reg("selected_supervisor")}/>
+          <Input {...reg("selected_supervisor")} disabled={isSubmitted}/>
         </div>
       </div>
       <div>
         <label className="block text-sm">Abstract (max 400 words)</label>
-        <textarea className="input h-24 w-full" {...reg("abstract")}></textarea>
+        <textarea className="input h-24 w-full" disabled={isSubmitted} {...reg("abstract")}></textarea>
       </div>
       <div>
         <label className="inline-flex items-center space-x-2">
-          <input type="checkbox" {...reg("has_secondment")}/>
+          <input type="checkbox" {...reg("has_secondment")} disabled={isSubmitted}/>
           <span>Has Secondment?</span>
         </label>
       </div>
       {hasSecondment && (
         <div className="space-y-2">
           <label className="inline-flex items-center space-x-2">
-            <input type="checkbox" {...reg("selected_from_db")}/>
+            <input type="checkbox" {...reg("selected_from_db")} disabled={isSubmitted}/>
             <span>Selected from DB</span>
           </label>
           {!watch("selected_from_db") && (
             <div>
               <label className="block text-sm">Secondment Institution Name</label>
-              <Input {...reg("institution_name")}/>
+              <Input {...reg("institution_name")} disabled={isSubmitted}/>
             </div>
           )}
         </div>
       )}
-      <button type="submit" className="mt-4 bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">Save</button>
+      <button type="submit" disabled={isSubmitted} className="mt-4 bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">Save</button>
     </form>
   );
 }

--- a/frontend/src/pages/calls/apply/Step4_DocumentsUpload.tsx
+++ b/frontend/src/pages/calls/apply/Step4_DocumentsUpload.tsx
@@ -12,6 +12,7 @@ export default function Step4_DocumentsUpload() {
     completeStep,
     markPartialStep,
     clearPartialStep,
+    isSubmitted,
   } = useApplication();
   const { show } = useToast();
   const [loading, setLoading] = useState(false);
@@ -71,12 +72,12 @@ export default function Step4_DocumentsUpload() {
           type="file"
           accept="application/pdf,image/jpeg,image/jpg"
           onChange={(e) => handleChange(e, "passport_or_id")}
-          disabled={loading}
+          disabled={loading || isSubmitted}
           className="block mt-2"
         />
         <DocumentList
           documents={attachments.filter((a) => a.field_name === "passport_or_id")}
-          onDelete={deleteAttachment}
+          onDelete={isSubmitted ? undefined : deleteAttachment}
         />
       </div>
 
@@ -86,18 +87,19 @@ export default function Step4_DocumentsUpload() {
           type="file"
           accept="application/pdf,image/jpeg,image/jpg"
           onChange={(e) => handleChange(e, "phd_certificate")}
-          disabled={loading}
+          disabled={loading || isSubmitted}
           className="block mt-2"
         />
         <DocumentList
           documents={attachments.filter((a) => a.field_name === "phd_certificate")}
-          onDelete={deleteAttachment}
+          onDelete={isSubmitted ? undefined : deleteAttachment}
         />
       </div>
 
       {error && <div className="text-red-500">Error: {error}</div>}
       <button
         onClick={handleSave}
+        disabled={isSubmitted}
         className="bg-blue-600 text-white px-4 py-2 rounded"
       >
         Save

--- a/frontend/src/pages/calls/apply/Step5_AcademicPortfolio.tsx
+++ b/frontend/src/pages/calls/apply/Step5_AcademicPortfolio.tsx
@@ -7,7 +7,7 @@ import { useApplication } from "../../../context/ApplicationProvider";
 import { useToast } from "../../../context/ToastProvider";
 
 export default function Step5_AcademicPortfolio() {
-  const { updateApplicationField, application, completeStep } = useApplication();
+  const { updateApplicationField, application, completeStep, isSubmitted } = useApplication();
   const { show } = useToast();
   const { register, control, handleSubmit, reset } = useForm({
     defaultValues: {},
@@ -37,39 +37,39 @@ export default function Step5_AcademicPortfolio() {
       <h2 className="text-lg font-semibold">Academic Portfolio</h2>
       <div>
         <label className="block text-sm">Doctoral Discipline</label>
-        <Input {...register("doctoral_discipline")} />
+        <Input {...register("doctoral_discipline")} disabled={isSubmitted} />
       </div>
       <div>
         <label className="block text-sm">Doctoral Thesis Title</label>
-        <Input {...register("doctoral_thesis_title")} />
+        <Input {...register("doctoral_thesis_title")} disabled={isSubmitted} />
       </div>
       <div>
         <label className="block text-sm">Awarding Institution</label>
-        <Input {...register("doctoral_awarding_institution")} />
+        <Input {...register("doctoral_awarding_institution")} disabled={isSubmitted} />
       </div>
       <div>
         <label className="block text-sm">Doctoral Award Date</label>
-        <Input type="date" {...register("doctoral_award_date")} />
+        <Input type="date" {...register("doctoral_award_date")} disabled={isSubmitted} />
       </div>
       <div>
         <label className="block text-sm">Current Institution</label>
-        <Input {...register("current_institution")} />
+        <Input {...register("current_institution")} disabled={isSubmitted} />
       </div>
       <div>
         <label className="block text-sm">Department</label>
-        <Input {...register("current_department")} />
+        <Input {...register("current_department")} disabled={isSubmitted} />
       </div>
       <div>
         <label className="block text-sm">Town/City</label>
-        <Input {...register("current_institution_town")} />
+        <Input {...register("current_institution_town")} disabled={isSubmitted} />
       </div>
       <div>
         <label className="block text-sm">Country</label>
-        <Input {...register("current_institution_country")} />
+        <Input {...register("current_institution_country")} disabled={isSubmitted} />
       </div>
       <div>
         <label className="block text-sm">Phone Number</label>
-        <Input {...register("current_phone_number")} />
+        <Input {...register("current_phone_number")} disabled={isSubmitted} />
       </div>
 
       <div className="pt-4">
@@ -78,43 +78,43 @@ export default function Step5_AcademicPortfolio() {
           <div key={field.id} className="border p-4 rounded mb-4 space-y-2">
             <div>
               <label className="block text-sm">Full Name</label>
-              <Input {...register(`reference_list.${index}.name_surname`)} />
+              <Input {...register(`reference_list.${index}.name_surname`)} disabled={isSubmitted} />
             </div>
             <div>
               <label className="block text-sm">Institution</label>
-              <Input {...register(`reference_list.${index}.institution`)} />
+              <Input {...register(`reference_list.${index}.institution`)} disabled={isSubmitted} />
             </div>
             <div>
               <label className="block text-sm">Department</label>
-              <Input {...register(`reference_list.${index}.department`)} />
+              <Input {...register(`reference_list.${index}.department`)} disabled={isSubmitted} />
             </div>
             <div>
               <label className="block text-sm">Country</label>
-              <Input {...register(`reference_list.${index}.country`)} />
+              <Input {...register(`reference_list.${index}.country`)} disabled={isSubmitted} />
             </div>
             <div>
               <label className="block text-sm">Position</label>
-              <Input {...register(`reference_list.${index}.position`)} />
+              <Input {...register(`reference_list.${index}.position`)} disabled={isSubmitted} />
             </div>
             <div>
               <label className="block text-sm">Phone Number</label>
-              <Input {...register(`reference_list.${index}.phone_number`)} />
+              <Input {...register(`reference_list.${index}.phone_number`)} disabled={isSubmitted} />
             </div>
             <div>
               <label className="block text-sm">Email</label>
-              <Input {...register(`reference_list.${index}.email`)} />
+              <Input {...register(`reference_list.${index}.email`)} disabled={isSubmitted} />
             </div>
             <div>
               <label className="block text-sm">Reason for Reference</label>
-              <Textarea {...register(`reference_list.${index}.reason`)} />
+              <Textarea {...register(`reference_list.${index}.reason`)} disabled={isSubmitted} />
             </div>
-            <Button type="button" onClick={() => remove(index)} variant="outline">Remove</Button>
-          </div>
-        ))}
-        <Button type="button" onClick={() => append({})}>Add Reference</Button>
+            <Button type="button" onClick={() => remove(index)} variant="outline" disabled={isSubmitted}>Remove</Button>
+        </div>
+      ))}
+        <Button type="button" onClick={() => append({})} disabled={isSubmitted}>Add Reference</Button>
       </div>
 
-      <Button type="submit">Save and Continue</Button>
+      <Button type="submit" disabled={isSubmitted}>Save and Continue</Button>
     </form>
   );
 }

--- a/frontend/src/pages/calls/apply/Step6_Mobility.tsx
+++ b/frontend/src/pages/calls/apply/Step6_Mobility.tsx
@@ -12,6 +12,7 @@ export default function Step6_Mobility() {
     removeMobilityEntry,
     mobilityEntries,
     completeStep,
+    isSubmitted,
   } = useApplication();
 
 
@@ -76,7 +77,7 @@ export default function Step6_Mobility() {
             <DatePicker
               value={entry.from_date}
               onChange={(e) => handleChange(index, "from_date", e.target.value)}
-
+              disabled={isSubmitted}
             />
           </div>
           <div>
@@ -84,6 +85,7 @@ export default function Step6_Mobility() {
             <DatePicker
               value={entry.to_date}
               onChange={(e) => handleChange(index, "to_date", e.target.value)}
+              disabled={isSubmitted}
             />
           </div>
           <div>
@@ -91,6 +93,7 @@ export default function Step6_Mobility() {
             <Input type="text"
               value={entry.organisation}
               onChange={(e) => handleChange(index, "organisation", e.target.value)}
+              disabled={isSubmitted}
             />
           </div>
           <div>
@@ -98,18 +101,19 @@ export default function Step6_Mobility() {
             <Input type="text"
               value={entry.country}
               onChange={(e) => handleChange(index, "country", e.target.value)}
+              disabled={isSubmitted}
             />
           </div>
           <div className="col-span-1 md:col-span-4 text-right">
-            <Button variant="destructive" onClick={() => handleRemove(index)}>
+            <Button variant="destructive" onClick={() => handleRemove(index)} disabled={isSubmitted}>
               Remove
             </Button>
           </div>
         </div>
       ))}
       <div className="space-x-2">
-        <Button onClick={handleAdd}>Add Mobility Entry</Button>
-        <Button onClick={handleSave}>Save All</Button>
+        <Button onClick={handleAdd} disabled={isSubmitted}>Add Mobility Entry</Button>
+        <Button onClick={handleSave} disabled={isSubmitted}>Save All</Button>
       </div>
     </div>
   );

--- a/frontend/src/pages/calls/apply/Step7_ProposalCV.tsx
+++ b/frontend/src/pages/calls/apply/Step7_ProposalCV.tsx
@@ -13,6 +13,7 @@ export default function Step7_ProposalCV() {
     completeStep,
     markPartialStep,
     clearPartialStep,
+    isSubmitted,
   } = useApplication();
 
 
@@ -75,12 +76,12 @@ export default function Step7_ProposalCV() {
         <FileInput
           accept="application/pdf"
           onChange={(e) => handleUpload(e, "proposal")}
-          disabled={loadingProposal}
+          disabled={loadingProposal || isSubmitted}
           className="mt-2"
         />
         <DocumentList
           documents={attachments.filter((a) => a.field_name === "proposal")}
-          onDelete={deleteAttachment}
+          onDelete={isSubmitted ? undefined : deleteAttachment}
         />
       </div>
 
@@ -100,12 +101,12 @@ export default function Step7_ProposalCV() {
         <FileInput
           accept="application/pdf"
           onChange={(e) => handleUpload(e, "cv")}
-          disabled={loadingCV}
+          disabled={loadingCV || isSubmitted}
           className="mt-2"
         />
         <DocumentList
           documents={attachments.filter((a) => a.field_name === "cv")}
-          onDelete={deleteAttachment}
+          onDelete={isSubmitted ? undefined : deleteAttachment}
         />
       </div>
 
@@ -119,6 +120,7 @@ export default function Step7_ProposalCV() {
             show("Please upload both files before completing this step");
           }
         }}
+        disabled={isSubmitted}
         className="bg-blue-600 text-white px-4 py-2 rounded"
       >
         Save

--- a/frontend/src/pages/calls/apply/Step8_EthicsSecurity.tsx
+++ b/frontend/src/pages/calls/apply/Step8_EthicsSecurity.tsx
@@ -1,11 +1,11 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useApplication } from "../../../context/ApplicationProvider";
 import { useToast } from "../../../context/ToastProvider";
 import EthicsIssuesTable from "../../../components/application/EthicsIssuesTable";
 import SecurityIssuesTable from "../../../components/application/SecurityIssuesTable";
 
 export default function Step8_EthicsSecurity() {
-  const { application, updateApplicationField, completeStep } = useApplication();
+  const { application, updateApplicationField, completeStep, isSubmitted } = useApplication();
   const { show } = useToast();
   const [ethicsConfirmed, setEthicsConfirmed] = useState(
     application.ethics_confirmed || false
@@ -19,6 +19,13 @@ export default function Step8_EthicsSecurity() {
   const [securitySelfAssessment, setSecuritySelfAssessment] = useState(
     application.security_self_assessment_text || ""
   );
+
+  useEffect(() => {
+    setEthicsConfirmed(application.ethics_confirmed || false);
+    setEthicalDescription(application.ethical_dimension_description || "");
+    setComplianceText(application.compliance_text || "");
+    setSecuritySelfAssessment(application.security_self_assessment_text || "");
+  }, [application]);
 
   const handleChange = () => {
     updateApplicationField("ethics_confirmed", ethicsConfirmed);
@@ -43,6 +50,7 @@ export default function Step8_EthicsSecurity() {
             type="checkbox"
             checked={ethicsConfirmed}
             onChange={(e) => setEthicsConfirmed(e.target.checked)}
+            disabled={isSubmitted}
           />
           <span>I confirm that I have reviewed the ethical issues.</span>
         </label>
@@ -52,6 +60,7 @@ export default function Step8_EthicsSecurity() {
             className="input w-full h-24"
             value={ethicalDescription}
             onChange={(e) => setEthicalDescription(e.target.value)}
+            disabled={isSubmitted}
           />
         </div>
         <div>
@@ -60,6 +69,7 @@ export default function Step8_EthicsSecurity() {
             className="input w-full h-24"
             value={complianceText}
             onChange={(e) => setComplianceText(e.target.value)}
+            disabled={isSubmitted}
           />
         </div>
       </div>
@@ -72,12 +82,14 @@ export default function Step8_EthicsSecurity() {
             className="input w-full h-24"
             value={securitySelfAssessment}
             onChange={(e) => setSecuritySelfAssessment(e.target.value)}
+            disabled={isSubmitted}
           />
         </div>
       </div>
 
       <button
         onClick={handleChange}
+        disabled={isSubmitted}
         className="bg-blue-600 text-white px-4 py-2 rounded shadow"
       >
         Save Section

--- a/frontend/src/pages/calls/apply/Step9_ReviewSubmit.tsx
+++ b/frontend/src/pages/calls/apply/Step9_ReviewSubmit.tsx
@@ -23,6 +23,7 @@ export default function Step9_ReviewSubmit() {
     completedSteps,
     partialSteps,
     completeStep,
+    isSubmitted,
   } = useApplication();
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
@@ -33,6 +34,7 @@ export default function Step9_ReviewSubmit() {
     (step) => step.path !== "step9" && !completedSteps.includes(step.path)
   );
   const hasPartial = partialSteps.length > 0;
+  const alreadySubmitted = isSubmitted || submitted;
 
   const handleSubmit = async () => {
     setSubmitting(true);
@@ -97,13 +99,13 @@ export default function Step9_ReviewSubmit() {
         </div>
       )}
 
-      {submitted ? (
+      {alreadySubmitted ? (
         <div className="text-green-600 font-medium">Application successfully submitted!</div>
       ) : (
         <>
           <Button
             onClick={() => setOpen(true)}
-            disabled={submitting || !applicationId || hasMissing || hasPartial}
+            disabled={submitting || !applicationId || hasMissing || hasPartial || isSubmitted}
           >
             {submitting ? "Submitting..." : "Submit Application"}
           </Button>


### PR DESCRIPTION
## Summary
- show stored data in ethics step by updating state
- disable editing when application is submitted
- mark submission in context and UI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6855380b36ec832cb0c88508c64844cb