### PR TITLE
Add auth checks to application-related routes

### DIFF
--- a/backend/app/routes/academic_portfolio.py
+++ b/backend/app/routes/academic_portfolio.py
@@ -4,36 +4,116 @@ import uuid
 
 from ..database import get_db
 from ..crud import academic_portfolio as crud
+from ..crud import application_form as crud_application_form
+from ..crud import application as crud_application
 from ..schemas import AcademicPortfolioCreate, AcademicPortfolioRead
+from ..core.security import get_current_user
+from ..core.enums import UserRole
+from ..models import User
 
 router = APIRouter(prefix="/academic_portfolios", tags=["AcademicPortfolio"])
 
 @router.post('/', response_model=AcademicPortfolioRead)
-def create_academic_portfolio(data: AcademicPortfolioCreate, db: Session = Depends(get_db)):
+def create_academic_portfolio(
+    data: AcademicPortfolioCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    app_form = crud_application_form.get_by_id(db, data.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return crud.create(db, data.dict())
 
 @router.get('/{obj_id}', response_model=AcademicPortfolioRead)
-def read_academic_portfolio(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+def read_academic_portfolio(
+    obj_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="AcademicPortfolio not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return obj
 
 @router.get('/', response_model=list[AcademicPortfolioRead])
-def read_academic_portfolios(db: Session = Depends(get_db)):
-    return list(crud.get_all(db))
+def read_academic_portfolios(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    portfolios = list(crud.get_all(db))
+    if current_user.role in {UserRole.admin, UserRole.super_admin}:
+        return portfolios
+    result = []
+    for obj in portfolios:
+        app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+        if not app_form:
+            continue
+        application = crud_application.get_by_id(db, app_form.application_id)
+        if application and application.user_id == current_user.id:
+            result.append(obj)
+    return result
 
 @router.put('/{obj_id}', response_model=AcademicPortfolioRead)
-def update_academic_portfolio(obj_id: uuid.UUID, data: AcademicPortfolioCreate, db: Session = Depends(get_db)):
+def update_academic_portfolio(
+    obj_id: uuid.UUID,
+    data: AcademicPortfolioCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="AcademicPortfolio not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return crud.update(db, obj, data.dict())
 
 @router.delete('/{obj_id}')
-def delete_academic_portfolio(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+def delete_academic_portfolio(
+    obj_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="AcademicPortfolio not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     crud.delete(db, obj)
-    return {'ok': True}
+    return {"ok": True}

--- a/backend/app/routes/academic_reference.py
+++ b/backend/app/routes/academic_reference.py
@@ -4,36 +4,116 @@ import uuid
 
 from ..database import get_db
 from ..crud import academic_reference as crud
+from ..crud import application_form as crud_application_form
+from ..crud import application as crud_application
 from ..schemas import AcademicReferenceCreate, AcademicReferenceRead
+from ..core.security import get_current_user
+from ..core.enums import UserRole
+from ..models import User
 
 router = APIRouter(prefix="/academic_references", tags=["AcademicReference"])
 
 @router.post('/', response_model=AcademicReferenceRead)
-def create_academic_reference(data: AcademicReferenceCreate, db: Session = Depends(get_db)):
+def create_academic_reference(
+    data: AcademicReferenceCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    app_form = crud_application_form.get_by_id(db, data.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return crud.create(db, data.dict())
 
 @router.get('/{obj_id}', response_model=AcademicReferenceRead)
-def read_academic_reference(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+def read_academic_reference(
+    obj_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="AcademicReference not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return obj
 
 @router.get('/', response_model=list[AcademicReferenceRead])
-def read_academic_references(db: Session = Depends(get_db)):
-    return list(crud.get_all(db))
+def read_academic_references(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    references = list(crud.get_all(db))
+    if current_user.role in {UserRole.admin, UserRole.super_admin}:
+        return references
+    result = []
+    for obj in references:
+        app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+        if not app_form:
+            continue
+        application = crud_application.get_by_id(db, app_form.application_id)
+        if application and application.user_id == current_user.id:
+            result.append(obj)
+    return result
 
 @router.put('/{obj_id}', response_model=AcademicReferenceRead)
-def update_academic_reference(obj_id: uuid.UUID, data: AcademicReferenceCreate, db: Session = Depends(get_db)):
+def update_academic_reference(
+    obj_id: uuid.UUID,
+    data: AcademicReferenceCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="AcademicReference not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return crud.update(db, obj, data.dict())
 
 @router.delete('/{obj_id}')
-def delete_academic_reference(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+def delete_academic_reference(
+    obj_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="AcademicReference not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     crud.delete(db, obj)
-    return {'ok': True}
+    return {"ok": True}

--- a/backend/app/routes/application_form.py
+++ b/backend/app/routes/application_form.py
@@ -4,36 +4,100 @@ import uuid
 
 from ..database import get_db
 from ..crud import application_form as crud
+from ..crud import application as crud_application
 from ..schemas import ApplicationFormCreate, ApplicationFormRead
+from ..core.security import get_current_user
+from ..core.enums import UserRole
+from ..models import User
 
 router = APIRouter(prefix="/application_forms", tags=["ApplicationForm"])
 
 @router.post('/', response_model=ApplicationFormRead)
-def create_application_form(data: ApplicationFormCreate, db: Session = Depends(get_db)):
+def create_application_form(
+    data: ApplicationFormCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    application = crud_application.get_by_id(db, data.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return crud.create(db, data.dict())
 
 @router.get('/{obj_id}', response_model=ApplicationFormRead)
-def read_application_form(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+def read_application_form(
+    obj_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, obj.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return obj
 
 @router.get('/', response_model=list[ApplicationFormRead])
-def read_application_forms(db: Session = Depends(get_db)):
-    return list(crud.get_all(db))
+def read_application_forms(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    forms = list(crud.get_all(db))
+    if current_user.role in {UserRole.admin, UserRole.super_admin}:
+        return forms
+    result = []
+    for obj in forms:
+        application = crud_application.get_by_id(db, obj.application_id)
+        if application and application.user_id == current_user.id:
+            result.append(obj)
+    return result
 
 @router.put('/{obj_id}', response_model=ApplicationFormRead)
-def update_application_form(obj_id: uuid.UUID, data: ApplicationFormCreate, db: Session = Depends(get_db)):
+def update_application_form(
+    obj_id: uuid.UUID,
+    data: ApplicationFormCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, obj.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return crud.update(db, obj, data.dict())
 
 @router.delete('/{obj_id}')
-def delete_application_form(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+def delete_application_form(
+    obj_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, obj.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     crud.delete(db, obj)
-    return {'ok': True}
+    return {"ok": True}

--- a/backend/app/routes/application_info.py
+++ b/backend/app/routes/application_info.py
@@ -4,36 +4,100 @@ import uuid
 
 from ..database import get_db
 from ..crud import application_info as crud
+from ..crud import application as crud_application
 from ..schemas import ApplicationInfoCreate, ApplicationInfoRead
+from ..core.security import get_current_user
+from ..core.enums import UserRole
+from ..models import User
 
 router = APIRouter(prefix="/application_infos", tags=["ApplicationInfo"])
 
 @router.post('/', response_model=ApplicationInfoRead)
-def create_application_info(data: ApplicationInfoCreate, db: Session = Depends(get_db)):
+def create_application_info(
+    data: ApplicationInfoCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    application = crud_application.get_by_id(db, data.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return crud.create(db, data.dict())
 
 @router.get('/{obj_id}', response_model=ApplicationInfoRead)
-def read_application_info(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+def read_application_info(
+    obj_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="ApplicationInfo not found")
+    application = crud_application.get_by_id(db, obj.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return obj
 
 @router.get('/', response_model=list[ApplicationInfoRead])
-def read_application_infos(db: Session = Depends(get_db)):
-    return list(crud.get_all(db))
+def read_application_infos(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    infos = list(crud.get_all(db))
+    if current_user.role in {UserRole.admin, UserRole.super_admin}:
+        return infos
+    result = []
+    for obj in infos:
+        application = crud_application.get_by_id(db, obj.application_id)
+        if application and application.user_id == current_user.id:
+            result.append(obj)
+    return result
 
 @router.put('/{obj_id}', response_model=ApplicationInfoRead)
-def update_application_info(obj_id: uuid.UUID, data: ApplicationInfoCreate, db: Session = Depends(get_db)):
+def update_application_info(
+    obj_id: uuid.UUID,
+    data: ApplicationInfoCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="ApplicationInfo not found")
+    application = crud_application.get_by_id(db, obj.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return crud.update(db, obj, data.dict())
 
 @router.delete('/{obj_id}')
-def delete_application_info(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+def delete_application_info(
+    obj_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="ApplicationInfo not found")
+    application = crud_application.get_by_id(db, obj.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     crud.delete(db, obj)
-    return {'ok': True}
+    return {"ok": True}

--- a/backend/app/routes/ethical_optional_table.py
+++ b/backend/app/routes/ethical_optional_table.py
@@ -4,36 +4,116 @@ import uuid
 
 from ..database import get_db
 from ..crud import ethical_optional_table as crud
+from ..crud import application_form as crud_application_form
+from ..crud import application as crud_application
 from ..schemas import EthicalOptionalTableCreate, EthicalOptionalTableRead
+from ..core.security import get_current_user
+from ..core.enums import UserRole
+from ..models import User
 
 router = APIRouter(prefix="/ethical_optional_tables", tags=["EthicalOptionalTable"])
 
 @router.post('/', response_model=EthicalOptionalTableRead)
-def create_ethical_optional_table(data: EthicalOptionalTableCreate, db: Session = Depends(get_db)):
+def create_ethical_optional_table(
+    data: EthicalOptionalTableCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    app_form = crud_application_form.get_by_id(db, data.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return crud.create(db, data.dict())
 
 @router.get('/{obj_id}', response_model=EthicalOptionalTableRead)
-def read_ethical_optional_table(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+def read_ethical_optional_table(
+    obj_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="EthicalOptionalTable not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return obj
 
 @router.get('/', response_model=list[EthicalOptionalTableRead])
-def read_ethical_optional_tables(db: Session = Depends(get_db)):
-    return list(crud.get_all(db))
+def read_ethical_optional_tables(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    tables = list(crud.get_all(db))
+    if current_user.role in {UserRole.admin, UserRole.super_admin}:
+        return tables
+    result = []
+    for obj in tables:
+        app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+        if not app_form:
+            continue
+        application = crud_application.get_by_id(db, app_form.application_id)
+        if application and application.user_id == current_user.id:
+            result.append(obj)
+    return result
 
 @router.put('/{obj_id}', response_model=EthicalOptionalTableRead)
-def update_ethical_optional_table(obj_id: uuid.UUID, data: EthicalOptionalTableCreate, db: Session = Depends(get_db)):
+def update_ethical_optional_table(
+    obj_id: uuid.UUID,
+    data: EthicalOptionalTableCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="EthicalOptionalTable not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return crud.update(db, obj, data.dict())
 
 @router.delete('/{obj_id}')
-def delete_ethical_optional_table(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+def delete_ethical_optional_table(
+    obj_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="EthicalOptionalTable not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     crud.delete(db, obj)
-    return {'ok': True}
+    return {"ok": True}

--- a/backend/app/routes/ethics_answer.py
+++ b/backend/app/routes/ethics_answer.py
@@ -4,36 +4,116 @@ import uuid
 
 from ..database import get_db
 from ..crud import ethics_answer as crud
+from ..crud import application_form as crud_application_form
+from ..crud import application as crud_application
 from ..schemas import EthicsAnswerCreate, EthicsAnswerRead
+from ..core.security import get_current_user
+from ..core.enums import UserRole
+from ..models import User
 
 router = APIRouter(prefix="/ethics_answers", tags=["EthicsAnswer"])
 
 @router.post('/', response_model=EthicsAnswerRead)
-def create_ethics_answer(data: EthicsAnswerCreate, db: Session = Depends(get_db)):
+def create_ethics_answer(
+    data: EthicsAnswerCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    app_form = crud_application_form.get_by_id(db, data.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return crud.create(db, data.dict())
 
 @router.get('/{obj_id}', response_model=EthicsAnswerRead)
-def read_ethics_answer(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+def read_ethics_answer(
+    obj_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="EthicsAnswer not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return obj
 
 @router.get('/', response_model=list[EthicsAnswerRead])
-def read_ethics_answers(db: Session = Depends(get_db)):
-    return list(crud.get_all(db))
+def read_ethics_answers(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    answers = list(crud.get_all(db))
+    if current_user.role in {UserRole.admin, UserRole.super_admin}:
+        return answers
+    result = []
+    for obj in answers:
+        app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+        if not app_form:
+            continue
+        application = crud_application.get_by_id(db, app_form.application_id)
+        if application and application.user_id == current_user.id:
+            result.append(obj)
+    return result
 
 @router.put('/{obj_id}', response_model=EthicsAnswerRead)
-def update_ethics_answer(obj_id: uuid.UUID, data: EthicsAnswerCreate, db: Session = Depends(get_db)):
+def update_ethics_answer(
+    obj_id: uuid.UUID,
+    data: EthicsAnswerCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="EthicsAnswer not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return crud.update(db, obj, data.dict())
 
 @router.delete('/{obj_id}')
-def delete_ethics_answer(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+def delete_ethics_answer(
+    obj_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="EthicsAnswer not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     crud.delete(db, obj)
-    return {'ok': True}
+    return {"ok": True}

--- a/backend/app/routes/ethics_issue.py
+++ b/backend/app/routes/ethics_issue.py
@@ -4,36 +4,116 @@ import uuid
 
 from ..database import get_db
 from ..crud import ethics_issue as crud
+from ..crud import application_form as crud_application_form
+from ..crud import application as crud_application
 from ..schemas import EthicsIssueCreate, EthicsIssueRead
+from ..core.security import get_current_user
+from ..core.enums import UserRole
+from ..models import User
 
 router = APIRouter(prefix="/ethics_issues", tags=["EthicsIssue"])
 
 @router.post('/', response_model=EthicsIssueRead)
-def create_ethics_issue(data: EthicsIssueCreate, db: Session = Depends(get_db)):
+def create_ethics_issue(
+    data: EthicsIssueCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    app_form = crud_application_form.get_by_id(db, data.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return crud.create(db, data.dict())
 
 @router.get('/{obj_id}', response_model=EthicsIssueRead)
-def read_ethics_issue(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+def read_ethics_issue(
+    obj_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="EthicsIssue not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return obj
 
 @router.get('/', response_model=list[EthicsIssueRead])
-def read_ethics_issues(db: Session = Depends(get_db)):
-    return list(crud.get_all(db))
+def read_ethics_issues(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    issues = list(crud.get_all(db))
+    if current_user.role in {UserRole.admin, UserRole.super_admin}:
+        return issues
+    result = []
+    for obj in issues:
+        app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+        if not app_form:
+            continue
+        application = crud_application.get_by_id(db, app_form.application_id)
+        if application and application.user_id == current_user.id:
+            result.append(obj)
+    return result
 
 @router.put('/{obj_id}', response_model=EthicsIssueRead)
-def update_ethics_issue(obj_id: uuid.UUID, data: EthicsIssueCreate, db: Session = Depends(get_db)):
+def update_ethics_issue(
+    obj_id: uuid.UUID,
+    data: EthicsIssueCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="EthicsIssue not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return crud.update(db, obj, data.dict())
 
 @router.delete('/{obj_id}')
-def delete_ethics_issue(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+def delete_ethics_issue(
+    obj_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="EthicsIssue not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     crud.delete(db, obj)
-    return {'ok': True}
+    return {"ok": True}

--- a/backend/app/routes/mobility_entry.py
+++ b/backend/app/routes/mobility_entry.py
@@ -4,44 +4,139 @@ import uuid
 
 from ..database import get_db
 from ..crud import mobility_entry as crud
+from ..crud import application_form as crud_application_form
+from ..crud import application as crud_application
 from ..schemas import MobilityEntryCreate, MobilityEntryRead
+from ..core.security import get_current_user
+from ..core.enums import UserRole
+from ..models import User
 
 router = APIRouter(prefix="/mobility_entries", tags=["MobilityEntry"])
 
 @router.post('/', response_model=MobilityEntryRead)
-def create_mobility_entry(data: MobilityEntryCreate, db: Session = Depends(get_db)):
+def create_mobility_entry(
+    data: MobilityEntryCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    app_form = crud_application_form.get_by_id(db, data.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return crud.create(db, data.dict())
 
 @router.get('/{obj_id}', response_model=MobilityEntryRead)
-def read_mobility_entry(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+def read_mobility_entry(
+    obj_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="MobilityEntry not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return obj
 
 @router.get('/', response_model=list[MobilityEntryRead])
-def read_mobility_entries(db: Session = Depends(get_db)):
-    return list(crud.get_all(db))
+def read_mobility_entries(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    entries = list(crud.get_all(db))
+    if current_user.role in {UserRole.admin, UserRole.super_admin}:
+        return entries
+    result = []
+    for obj in entries:
+        app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+        if not app_form:
+            continue
+        application = crud_application.get_by_id(db, app_form.application_id)
+        if application and application.user_id == current_user.id:
+            result.append(obj)
+    return result
 
 
 @router.get('/application_form/{application_form_id}', response_model=list[MobilityEntryRead])
 def read_mobility_entries_by_application_form(
-    application_form_id: uuid.UUID, db: Session = Depends(get_db)
+    application_form_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
 ):
     """Return mobility entries belonging to a specific application form."""
-    return list(crud.get_mobility_entries_by_application_form_id(db, application_form_id))
+    app_form = crud_application_form.get_by_id(db, application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
+    return list(
+        crud.get_mobility_entries_by_application_form_id(db, application_form_id)
+    )
 
 @router.put('/{obj_id}', response_model=MobilityEntryRead)
-def update_mobility_entry(obj_id: uuid.UUID, data: MobilityEntryCreate, db: Session = Depends(get_db)):
+def update_mobility_entry(
+    obj_id: uuid.UUID,
+    data: MobilityEntryCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="MobilityEntry not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return crud.update(db, obj, data.dict())
 
 @router.delete('/{obj_id}')
-def delete_mobility_entry(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+def delete_mobility_entry(
+    obj_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="MobilityEntry not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     crud.delete(db, obj)
-    return {'ok': True}
+    return {"ok": True}

--- a/backend/app/routes/security_answer.py
+++ b/backend/app/routes/security_answer.py
@@ -4,36 +4,116 @@ import uuid
 
 from ..database import get_db
 from ..crud import security_answer as crud
+from ..crud import application_form as crud_application_form
+from ..crud import application as crud_application
 from ..schemas import SecurityAnswerCreate, SecurityAnswerRead
+from ..core.security import get_current_user
+from ..core.enums import UserRole
+from ..models import User
 
 router = APIRouter(prefix="/security_answers", tags=["SecurityAnswer"])
 
 @router.post('/', response_model=SecurityAnswerRead)
-def create_security_answer(data: SecurityAnswerCreate, db: Session = Depends(get_db)):
+def create_security_answer(
+    data: SecurityAnswerCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    app_form = crud_application_form.get_by_id(db, data.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return crud.create(db, data.dict())
 
 @router.get('/{obj_id}', response_model=SecurityAnswerRead)
-def read_security_answer(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+def read_security_answer(
+    obj_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="SecurityAnswer not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return obj
 
 @router.get('/', response_model=list[SecurityAnswerRead])
-def read_security_answers(db: Session = Depends(get_db)):
-    return list(crud.get_all(db))
+def read_security_answers(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    answers = list(crud.get_all(db))
+    if current_user.role in {UserRole.admin, UserRole.super_admin}:
+        return answers
+    result = []
+    for obj in answers:
+        app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+        if not app_form:
+            continue
+        application = crud_application.get_by_id(db, app_form.application_id)
+        if application and application.user_id == current_user.id:
+            result.append(obj)
+    return result
 
 @router.put('/{obj_id}', response_model=SecurityAnswerRead)
-def update_security_answer(obj_id: uuid.UUID, data: SecurityAnswerCreate, db: Session = Depends(get_db)):
+def update_security_answer(
+    obj_id: uuid.UUID,
+    data: SecurityAnswerCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="SecurityAnswer not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return crud.update(db, obj, data.dict())
 
 @router.delete('/{obj_id}')
-def delete_security_answer(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+def delete_security_answer(
+    obj_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="SecurityAnswer not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     crud.delete(db, obj)
-    return {'ok': True}
+    return {"ok": True}

--- a/backend/app/routes/security_euci.py
+++ b/backend/app/routes/security_euci.py
@@ -4,40 +4,120 @@ import uuid
 
 from ..database import get_db
 from ..crud import security_euci as crud
+from ..crud import application_form as crud_application_form
+from ..crud import application as crud_application
 # Pydantic schemas expose classes with the acronym EUCI fully capitalized. The
 # previous import used `SecurityEuciCreate`/`SecurityEuciRead`, which do not
 # exist and caused an `ImportError` during application startup. Import the
 # correctly named classes instead.
 from ..schemas import SecurityEUCCreate, SecurityEUCIRead
+from ..core.security import get_current_user
+from ..core.enums import UserRole
+from ..models import User
 
 router = APIRouter(prefix="/security_eucis", tags=["SecurityEuci"])
 
 @router.post('/', response_model=SecurityEUCIRead)
-def create_security_euci(data: SecurityEUCCreate, db: Session = Depends(get_db)):
+def create_security_euci(
+    data: SecurityEUCCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    app_form = crud_application_form.get_by_id(db, data.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return crud.create(db, data.dict())
 
 @router.get('/{obj_id}', response_model=SecurityEUCIRead)
-def read_security_euci(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+def read_security_euci(
+    obj_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="SecurityEuci not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return obj
 
 @router.get('/', response_model=list[SecurityEUCIRead])
-def read_security_eucis(db: Session = Depends(get_db)):
-    return list(crud.get_all(db))
+def read_security_eucis(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    eucis = list(crud.get_all(db))
+    if current_user.role in {UserRole.admin, UserRole.super_admin}:
+        return eucis
+    result = []
+    for obj in eucis:
+        app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+        if not app_form:
+            continue
+        application = crud_application.get_by_id(db, app_form.application_id)
+        if application and application.user_id == current_user.id:
+            result.append(obj)
+    return result
 
 @router.put('/{obj_id}', response_model=SecurityEUCIRead)
-def update_security_euci(obj_id: uuid.UUID, data: SecurityEUCCreate, db: Session = Depends(get_db)):
+def update_security_euci(
+    obj_id: uuid.UUID,
+    data: SecurityEUCCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="SecurityEuci not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return crud.update(db, obj, data.dict())
 
 @router.delete('/{obj_id}')
-def delete_security_euci(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+def delete_security_euci(
+    obj_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="SecurityEuci not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     crud.delete(db, obj)
-    return {'ok': True}
+    return {"ok": True}

--- a/backend/app/routes/security_misuse.py
+++ b/backend/app/routes/security_misuse.py
@@ -4,36 +4,116 @@ import uuid
 
 from ..database import get_db
 from ..crud import security_misuse as crud
+from ..crud import application_form as crud_application_form
+from ..crud import application as crud_application
 from ..schemas import SecurityMisuseCreate, SecurityMisuseRead
+from ..core.security import get_current_user
+from ..core.enums import UserRole
+from ..models import User
 
 router = APIRouter(prefix="/security_misuses", tags=["SecurityMisuse"])
 
 @router.post('/', response_model=SecurityMisuseRead)
-def create_security_misuse(data: SecurityMisuseCreate, db: Session = Depends(get_db)):
+def create_security_misuse(
+    data: SecurityMisuseCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    app_form = crud_application_form.get_by_id(db, data.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return crud.create(db, data.dict())
 
 @router.get('/{obj_id}', response_model=SecurityMisuseRead)
-def read_security_misuse(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+def read_security_misuse(
+    obj_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="SecurityMisuse not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return obj
 
 @router.get('/', response_model=list[SecurityMisuseRead])
-def read_security_misuses(db: Session = Depends(get_db)):
-    return list(crud.get_all(db))
+def read_security_misuses(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    misuses = list(crud.get_all(db))
+    if current_user.role in {UserRole.admin, UserRole.super_admin}:
+        return misuses
+    result = []
+    for obj in misuses:
+        app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+        if not app_form:
+            continue
+        application = crud_application.get_by_id(db, app_form.application_id)
+        if application and application.user_id == current_user.id:
+            result.append(obj)
+    return result
 
 @router.put('/{obj_id}', response_model=SecurityMisuseRead)
-def update_security_misuse(obj_id: uuid.UUID, data: SecurityMisuseCreate, db: Session = Depends(get_db)):
+def update_security_misuse(
+    obj_id: uuid.UUID,
+    data: SecurityMisuseCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="SecurityMisuse not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return crud.update(db, obj, data.dict())
 
 @router.delete('/{obj_id}')
-def delete_security_misuse(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+def delete_security_misuse(
+    obj_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="SecurityMisuse not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     crud.delete(db, obj)
-    return {'ok': True}
+    return {"ok": True}

--- a/backend/app/routes/security_other.py
+++ b/backend/app/routes/security_other.py
@@ -4,36 +4,116 @@ import uuid
 
 from ..database import get_db
 from ..crud import security_other as crud
+from ..crud import application_form as crud_application_form
+from ..crud import application as crud_application
 from ..schemas import SecurityOtherCreate, SecurityOtherRead
+from ..core.security import get_current_user
+from ..core.enums import UserRole
+from ..models import User
 
 router = APIRouter(prefix="/security_others", tags=["SecurityOther"])
 
 @router.post('/', response_model=SecurityOtherRead)
-def create_security_other(data: SecurityOtherCreate, db: Session = Depends(get_db)):
+def create_security_other(
+    data: SecurityOtherCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    app_form = crud_application_form.get_by_id(db, data.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return crud.create(db, data.dict())
 
 @router.get('/{obj_id}', response_model=SecurityOtherRead)
-def read_security_other(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+def read_security_other(
+    obj_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="SecurityOther not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return obj
 
 @router.get('/', response_model=list[SecurityOtherRead])
-def read_security_others(db: Session = Depends(get_db)):
-    return list(crud.get_all(db))
+def read_security_others(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    others = list(crud.get_all(db))
+    if current_user.role in {UserRole.admin, UserRole.super_admin}:
+        return others
+    result = []
+    for obj in others:
+        app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+        if not app_form:
+            continue
+        application = crud_application.get_by_id(db, app_form.application_id)
+        if application and application.user_id == current_user.id:
+            result.append(obj)
+    return result
 
 @router.put('/{obj_id}', response_model=SecurityOtherRead)
-def update_security_other(obj_id: uuid.UUID, data: SecurityOtherCreate, db: Session = Depends(get_db)):
+def update_security_other(
+    obj_id: uuid.UUID,
+    data: SecurityOtherCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="SecurityOther not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return crud.update(db, obj, data.dict())
 
 @router.delete('/{obj_id}')
-def delete_security_other(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+def delete_security_other(
+    obj_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="SecurityOther not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     crud.delete(db, obj)
-    return {'ok': True}
+    return {"ok": True}

--- a/backend/app/routes/suggested_reference.py
+++ b/backend/app/routes/suggested_reference.py
@@ -4,36 +4,116 @@ import uuid
 
 from ..database import get_db
 from ..crud import suggested_reference as crud
+from ..crud import application_form as crud_application_form
+from ..crud import application as crud_application
 from ..schemas import SuggestedReferenceCreate, SuggestedReferenceRead
+from ..core.security import get_current_user
+from ..core.enums import UserRole
+from ..models import User
 
 router = APIRouter(prefix="/suggested_references", tags=["SuggestedReference"])
 
 @router.post('/', response_model=SuggestedReferenceRead)
-def create_suggested_reference(data: SuggestedReferenceCreate, db: Session = Depends(get_db)):
+def create_suggested_reference(
+    data: SuggestedReferenceCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    app_form = crud_application_form.get_by_id(db, data.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return crud.create(db, data.dict())
 
 @router.get('/{obj_id}', response_model=SuggestedReferenceRead)
-def read_suggested_reference(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+def read_suggested_reference(
+    obj_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="SuggestedReference not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return obj
 
 @router.get('/', response_model=list[SuggestedReferenceRead])
-def read_suggested_references(db: Session = Depends(get_db)):
-    return list(crud.get_all(db))
+def read_suggested_references(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    refs = list(crud.get_all(db))
+    if current_user.role in {UserRole.admin, UserRole.super_admin}:
+        return refs
+    result = []
+    for obj in refs:
+        app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+        if not app_form:
+            continue
+        application = crud_application.get_by_id(db, app_form.application_id)
+        if application and application.user_id == current_user.id:
+            result.append(obj)
+    return result
 
 @router.put('/{obj_id}', response_model=SuggestedReferenceRead)
-def update_suggested_reference(obj_id: uuid.UUID, data: SuggestedReferenceCreate, db: Session = Depends(get_db)):
+def update_suggested_reference(
+    obj_id: uuid.UUID,
+    data: SuggestedReferenceCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="SuggestedReference not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return crud.update(db, obj, data.dict())
 
 @router.delete('/{obj_id}')
-def delete_suggested_reference(obj_id: uuid.UUID, db: Session = Depends(get_db)):
+def delete_suggested_reference(
+    obj_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     obj = crud.get_by_id(db, obj_id)
     if not obj:
         raise HTTPException(status_code=404, detail="SuggestedReference not found")
+    app_form = crud_application_form.get_by_id(db, obj.application_form_id)
+    if not app_form:
+        raise HTTPException(status_code=404, detail="ApplicationForm not found")
+    application = crud_application.get_by_id(db, app_form.application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if (
+        application.user_id != current_user.id
+        and current_user.role not in {UserRole.admin, UserRole.super_admin}
+    ):
+        raise HTTPException(status_code=403, detail="Forbidden")
     crud.delete(db, obj)
-    return {'ok': True}
+    return {"ok": True}


### PR DESCRIPTION
## Summary
- secure more endpoints by injecting `current_user` dependencies
- ensure only application owners or admins can manipulate application sub-resources

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685540497200832ca4c690d1fc9f6f57