### PR TITLE
Add attachment confirm endpoint

### DIFF
--- a/backend/app/crud/attachment.py
+++ b/backend/app/crud/attachment.py
@@ -24,5 +24,12 @@ def delete(db: Session, obj: Attachment) -> None:
     _delete(db, obj)
 
 
+def confirm(db: Session, obj: Attachment) -> Attachment:
+    obj.confirmed = True
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+
 def get_attachments_by_application_id(db: Session, application_id: str, include_deleted: bool = False):
     return get_all_by_field(db, Attachment, 'application_id', application_id, include_deleted)

--- a/frontend/src/api/applications.ts
+++ b/frontend/src/api/applications.ts
@@ -74,3 +74,7 @@ export function getApplicationAttachments(id: string) {
 export function deleteAttachment(id: string) {
   return apiFetch(`/attachments/${id}`, { method: "DELETE" });
 }
+
+export function confirmAttachment(id: string) {
+  return apiFetch(`/attachments/${id}/confirm`, { method: "PATCH" });
+}


### PR DESCRIPTION
## Summary
- add route to confirm attachment in backend
- add CRUD helper to set attachment.confirmed
- expose confirmAttachment helper in frontend API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685540552c7c832caa69b3e0f73e8062