### PR TITLE
Add unique constraint and duplicate application handling

### DIFF
--- a/backend/app/models/application.py
+++ b/backend/app/models/application.py
@@ -18,3 +18,7 @@ class Application(Base, SoftDeleteMixin):
     info = relationship('ApplicationInfo', back_populates='application', uselist=False)
     form = relationship('ApplicationForm', back_populates='application', uselist=False)
     review_reports = relationship('ReviewReport', back_populates='application')
+
+    __table_args__ = (
+        UniqueConstraint('call_id', 'user_id', 'is_deleted', name='uq_application_call_user'),
+    )


### PR DESCRIPTION
## Summary
- enforce call/user uniqueness by adding a new composite `UniqueConstraint`
- catch `IntegrityError` when creating an application and return a 400 response

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68554056772c832c95524e26422f8a14