### PR TITLE
Fix application load failure handling

### DIFF
--- a/frontend/src/context/ApplicationProvider.tsx
+++ b/frontend/src/context/ApplicationProvider.tsx
@@ -130,6 +130,8 @@ export function ApplicationProvider({
       } catch {
         setApplication({});
         setAttachments([]);
+        setApplicationId(null);
+        localStorage.removeItem(`applicationId_${callId}`);
         show("Failed to load application");
       }
     };


### PR DESCRIPTION
## Summary
- clear invalid application IDs when failing to fetch application data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68554052fd40832ca6cba8a7385864e7