### PR TITLE
Implement programmatic attachment download

### DIFF
--- a/frontend/src/components/ui/DocumentList.tsx
+++ b/frontend/src/components/ui/DocumentList.tsx
@@ -2,8 +2,7 @@
 import { useState } from "react";
 import { Attachment } from "../../types/application";
 import ConfirmModal from "./ConfirmModal";
-
-const API_BASE = import.meta.env.VITE_API_BASE || "http://localhost:8000";
+import { apiFetch } from "../../lib/api";
 
 export default function DocumentList({
   documents,
@@ -13,6 +12,21 @@ export default function DocumentList({
   onDelete?: (id: string) => void;
 }) {
   const [confirmId, setConfirmId] = useState<string | null>(null);
+  const handleDownload = async (doc: Attachment) => {
+    try {
+      const blob = (await apiFetch(`/files/${doc.id}`, { asBlob: true })) as Blob;
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = doc.doc_name;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error(err);
+    }
+  };
   if (documents.length === 0) {
     return <p>No documents uploaded.</p>;
   }
@@ -21,13 +35,12 @@ export default function DocumentList({
     <ul className="space-y-2">
       {documents.map((doc) => (
         <li key={doc.id} className="flex justify-between border p-2 rounded">
-          <a
-            href={`${API_BASE}/files/${doc.id}`}
+          <button
+            onClick={() => handleDownload(doc)}
             className="text-blue-600 underline"
-            download
           >
             {doc.field_name ? `${doc.field_name}: ${doc.doc_name}` : doc.doc_name}
-          </a>
+          </button>
           {onDelete && (
             <>
               <button

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,7 +2,10 @@
 
 const API_BASE = import.meta.env.VITE_API_BASE || "http://localhost:8000";
 
-export async function apiFetch(path: string, options: RequestInit = {}) {
+export async function apiFetch(
+  path: string,
+  options: RequestInit & { asBlob?: boolean } = {}
+) {
   const token = localStorage.getItem("token");
   const headers = new Headers(options.headers);
   if (token) {
@@ -28,6 +31,9 @@ export async function apiFetch(path: string, options: RequestInit = {}) {
     throw new Error(message);
   }
   if (res.status === 204) return null;
+  if (options.asBlob) {
+    return res.blob();
+  }
   return res.json();
 }
 


### PR DESCRIPTION
## Summary
- extend `apiFetch` helper with `asBlob` option for binary responses
- update `DocumentList` to download files via `apiFetch` and object URLs

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68554068ed6c832c923209e63575fe8a