### PR TITLE
Handle API auth errors gracefully

### DIFF
--- a/frontend/src/context/ApplicationProvider.tsx
+++ b/frontend/src/context/ApplicationProvider.tsx
@@ -21,6 +21,7 @@ import { Call } from "../types/global";
 import { Attachment } from "../types/application";
 import type { MobilityEntry, MobilityEntryInput } from "../types/mobility.types";
 import { useToast } from "./ToastProvider";
+import { ApiError } from "../lib/api";
 
 
 interface ApplicationContextValue {
@@ -127,7 +128,14 @@ export function ApplicationProvider({
         setApplicationFormId(app.application_form_id ?? null);
         setAttachments(files);
         setCompletedSteps(app.completed_steps || []);
-      } catch {
+      } catch (err) {
+        if (
+          err instanceof ApiError &&
+          (err.status === 401 || err.status === 403)
+        ) {
+          show("Session expired. Please log in again.");
+          return;
+        }
         setApplication({});
         setAttachments([]);
         setApplicationId(null);
@@ -140,7 +148,14 @@ export function ApplicationProvider({
       try {
         const data = await apiGetMobilityEntries(applicationFormId);
         setMobilityEntries(data);
-      } catch {
+      } catch (err) {
+        if (
+          err instanceof ApiError &&
+          (err.status === 401 || err.status === 403)
+        ) {
+          show("Session expired. Please log in again.");
+          return;
+        }
         setMobilityEntries([]);
         show("Failed to load mobility entries");
       }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,6 +2,15 @@
 
 const API_BASE = import.meta.env.VITE_API_BASE || "http://localhost:8000";
 
+export class ApiError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
 export async function apiFetch(
   path: string,
   options: RequestInit & { asBlob?: boolean } = {}
@@ -28,7 +37,7 @@ export async function apiFetch(
         if (text) message = text;
       } catch {}
     }
-    throw new Error(message);
+    throw new ApiError(res.status, message);
   }
   if (res.status === 204) return null;
   if (options.asBlob) {


### PR DESCRIPTION
## Summary
- add `ApiError` for unified HTTP error handling
- throw `ApiError` from `apiFetch`
- detect expired session in `ApplicationProvider` without clearing form state

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6855a52ab218832caff89bc87d4ba55c