### PR TITLE
Update application form handling

### DIFF
--- a/frontend/src/api/applicationForms.ts
+++ b/frontend/src/api/applicationForms.ts
@@ -1,0 +1,25 @@
+import { apiFetch } from "../lib/api";
+import type {
+  ApplicationForm,
+  ApplicationFormCreate,
+} from "../types/applicationForm.types";
+
+export function createApplicationForm(data: ApplicationFormCreate) {
+  return apiFetch("/application_forms", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  }) as Promise<ApplicationForm>;
+}
+
+export function getApplicationForm(id: string) {
+  return apiFetch(`/application_forms/${id}`) as Promise<ApplicationForm>;
+}
+
+export function updateApplicationForm(id: string, data: ApplicationFormCreate) {
+  return apiFetch(`/application_forms/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  }) as Promise<ApplicationForm>;
+}

--- a/frontend/src/context/ApplicationProvider.tsx
+++ b/frontend/src/context/ApplicationProvider.tsx
@@ -11,6 +11,11 @@ import {
   getApplicationAttachments,
 } from "../api/applications";
 import {
+  createApplicationForm as apiCreateApplicationForm,
+  getApplicationForm as apiGetApplicationForm,
+  updateApplicationForm as apiUpdateApplicationForm,
+} from "../api/applicationForms";
+import {
   getMobilityEntries as apiGetMobilityEntries,
   createMobilityEntry as apiCreateMobilityEntry,
   updateMobilityEntry as apiUpdateMobilityEntry,
@@ -28,6 +33,7 @@ interface ApplicationContextValue {
   call: Call | null;
   applicationId: string | null;
   applicationFormId: string | null;
+  applicationForm: Record<string, any>;
   application: Record<string, any>;
   attachments: Attachment[];
   mobilityEntries: MobilityEntry[];
@@ -43,6 +49,7 @@ interface ApplicationContextValue {
   removeMobilityEntry: (id: string) => Promise<boolean>;
   submitApplication: () => Promise<boolean>;
   updateApplicationField: (field: string, value: unknown) => Promise<void>;
+  updateApplicationFormField: (field: string, value: unknown) => Promise<void>;
   completeStep: (step: string) => Promise<void>;
   markPartialStep: (step: string) => void;
   clearPartialStep: (step: string) => void;
@@ -53,6 +60,7 @@ const ApplicationContext = createContext<ApplicationContextValue>({
   call: null,
   applicationId: null,
   applicationFormId: null,
+  applicationForm: {},
   application: {},
   attachments: [],
   mobilityEntries: [],
@@ -68,6 +76,7 @@ const ApplicationContext = createContext<ApplicationContextValue>({
   removeMobilityEntry: async () => false,
   submitApplication: async () => false,
   updateApplicationField: async () => {},
+  updateApplicationFormField: async () => {},
   completeStep: async () => {},
   isSubmitted: false,
 });
@@ -91,6 +100,7 @@ export function ApplicationProvider({
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [mobilityEntries, setMobilityEntries] = useState<MobilityEntry[]>([]);
   const [applicationFormId, setApplicationFormId] = useState<string | null>(null);
+  const [applicationForm, setApplicationForm] = useState<Record<string, any>>({});
   const [completedSteps, setCompletedSteps] = useState<string[]>([]);
   const [partialSteps, setPartialSteps] = useState<string[]>([]);
   const { show } = useToast();
@@ -108,6 +118,22 @@ export function ApplicationProvider({
     };
     fetchCall();
   }, [callId, show]);
+
+  useEffect(() => {
+    if (!applicationFormId) {
+      setApplicationForm({});
+      return;
+    }
+    const fetchForm = async () => {
+      try {
+        const form = await apiGetApplicationForm(applicationFormId);
+        setApplicationForm(form);
+      } catch {
+        setApplicationForm({});
+      }
+    };
+    fetchForm();
+  }, [applicationFormId]);
 
   useEffect(() => {
     if (!applicationId) {
@@ -128,6 +154,14 @@ export function ApplicationProvider({
         setApplicationFormId(app.application_form_id ?? null);
         setAttachments(files);
         setCompletedSteps(app.completed_steps || []);
+        if (app.application_form_id) {
+          try {
+            const form = await apiGetApplicationForm(app.application_form_id);
+            setApplicationForm(form);
+          } catch {
+            setApplicationForm({});
+          }
+        }
       } catch (err) {
         if (
           err instanceof ApiError &&
@@ -170,11 +204,32 @@ export function ApplicationProvider({
     try {
       const data = await apiCreateApplication(callId);
       setApplicationId(data.id as string);
-      if ("application_form_id" in data) {
-        setApplicationFormId((data as any).application_form_id as string);
-      }
       setApplication({ ...data, completed_steps: [] } as Record<string, any>);
       setCompletedSteps([]);
+
+      let formId = (data as any).application_form_id as string | undefined;
+      if (formId) {
+        setApplicationFormId(formId);
+        try {
+          const form = await apiGetApplicationForm(formId);
+          setApplicationForm(form);
+        } catch {
+          setApplicationForm({});
+        }
+      } else {
+        try {
+          const form = await apiCreateApplicationForm({
+            application_id: data.id as string,
+          });
+          formId = form.id as string;
+          setApplicationFormId(formId);
+          setApplicationForm(form);
+        } catch {
+          setApplicationFormId(null);
+          setApplicationForm({});
+        }
+      }
+
       return data.id as string;
     } catch {
       show("Failed to create application");
@@ -227,6 +282,20 @@ export function ApplicationProvider({
       await patchApplication(applicationId, { [field]: value });
     } catch {
       show("Failed to update application");
+    }
+  };
+
+  const updateApplicationFormField = async (field: string, value: unknown) => {
+    if (!applicationFormId) return;
+    setApplicationForm((prev) => ({ ...prev, [field]: value }));
+    try {
+      await apiUpdateApplicationForm(applicationFormId, {
+        ...applicationForm,
+        [field]: value,
+        application_id: applicationId as string,
+      });
+    } catch {
+      show("Failed to update application form");
     }
   };
 
@@ -314,6 +383,7 @@ export function ApplicationProvider({
         call,
         applicationId,
         applicationFormId,
+        applicationForm,
         application,
         attachments,
         mobilityEntries,
@@ -329,6 +399,7 @@ export function ApplicationProvider({
         removeMobilityEntry,
         submitApplication,
         updateApplicationField,
+        updateApplicationFormField,
         completeStep,
         markPartialStep,
         clearPartialStep,

--- a/frontend/src/pages/calls/apply/Step2_ApplicantInfo.tsx
+++ b/frontend/src/pages/calls/apply/Step2_ApplicantInfo.tsx
@@ -14,7 +14,7 @@ import {
 
 
 export default function Step2_ApplicantInfo() {
-  const { updateApplicationField, application, completeStep, isSubmitted } = useApplication();
+  const { updateApplicationFormField, applicationForm, completeStep, isSubmitted } = useApplication();
   const { show } = useToast();
   const {
     register,
@@ -27,13 +27,13 @@ export default function Step2_ApplicantInfo() {
   });
 
   useEffect(() => {
-    reset(application as Partial<ApplicantInfoForm>);
-  }, [application, reset]);
+    reset(applicationForm as Partial<ApplicantInfoForm>);
+  }, [applicationForm, reset]);
 
   const onSubmit = async (data: ApplicantInfoForm) => {
     try {
       for (const [field, value] of Object.entries(data)) {
-        await updateApplicationField(field, value);
+        await updateApplicationFormField(field, value);
       }
       await completeStep("step2");
       show("Applicant Info saved");

--- a/frontend/src/pages/calls/apply/Step3_ApplicationDetails.tsx
+++ b/frontend/src/pages/calls/apply/Step3_ApplicationDetails.tsx
@@ -22,7 +22,7 @@ const schema = z.object({
 type FormValues = z.infer<typeof schema>;
 
 export default function Step3_ApplicationDetails() {
-  const { application, updateApplicationField, completeStep, isSubmitted } = useApplication();
+  const { applicationForm, updateApplicationFormField, completeStep, isSubmitted } = useApplication();
   const { show } = useToast();
 
 
@@ -38,8 +38,8 @@ export default function Step3_ApplicationDetails() {
   });
 
   useEffect(() => {
-    reset(application as Partial<FormValues>);
-  }, [application, reset]);
+    reset(applicationForm as Partial<FormValues>);
+  }, [applicationForm, reset]);
 
   const onSubmit = async () => {
     await completeStep("step3");
@@ -52,12 +52,12 @@ export default function Step3_ApplicationDetails() {
         if (isSubmitted) return;
         const value =
           e.target.type === "checkbox" ? (e.target as HTMLInputElement).checked : e.target.value;
-        updateApplicationField(name, value);
+        updateApplicationFormField(name, value);
       },
       onChange: (e) => {
         if (isSubmitted) return;
         if (e.target.type === "checkbox") {
-          updateApplicationField(name, (e.target as HTMLInputElement).checked);
+          updateApplicationFormField(name, (e.target as HTMLInputElement).checked);
         }
       },
     });

--- a/frontend/src/pages/calls/apply/Step5_AcademicPortfolio.tsx
+++ b/frontend/src/pages/calls/apply/Step5_AcademicPortfolio.tsx
@@ -7,15 +7,15 @@ import { useApplication } from "../../../context/ApplicationProvider";
 import { useToast } from "../../../context/ToastProvider";
 
 export default function Step5_AcademicPortfolio() {
-  const { updateApplicationField, application, completeStep, isSubmitted } = useApplication();
+  const { updateApplicationFormField, applicationForm, completeStep, isSubmitted } = useApplication();
   const { show } = useToast();
   const { register, control, handleSubmit, reset } = useForm({
     defaultValues: {},
   });
 
   useEffect(() => {
-    reset(application as any);
-  }, [application, reset]);
+    reset(applicationForm as any);
+  }, [applicationForm, reset]);
 
   const { fields, append, remove } = useFieldArray({
     control,
@@ -24,7 +24,9 @@ export default function Step5_AcademicPortfolio() {
 
   const onSubmit = async (data: any) => {
     try {
-      await updateApplicationField("academic_portfolio", data);
+      for (const [field, value] of Object.entries(data)) {
+        await updateApplicationFormField(field, value);
+      }
       await completeStep("step5");
       show("Academic portfolio saved");
     } catch {

--- a/frontend/src/pages/calls/apply/Step8_EthicsSecurity.tsx
+++ b/frontend/src/pages/calls/apply/Step8_EthicsSecurity.tsx
@@ -5,33 +5,33 @@ import EthicsIssuesTable from "../../../components/application/EthicsIssuesTable
 import SecurityIssuesTable from "../../../components/application/SecurityIssuesTable";
 
 export default function Step8_EthicsSecurity() {
-  const { application, updateApplicationField, completeStep, isSubmitted } = useApplication();
+  const { applicationForm, updateApplicationFormField, completeStep, isSubmitted } = useApplication();
   const { show } = useToast();
   const [ethicsConfirmed, setEthicsConfirmed] = useState(
-    application.ethics_confirmed || false
+    applicationForm.ethics_confirmed || false
   );
   const [ethicalDescription, setEthicalDescription] = useState(
-    application.ethical_dimension_description || ""
+    applicationForm.ethical_dimension_description || ""
   );
   const [complianceText, setComplianceText] = useState(
-    application.compliance_text || ""
+    applicationForm.compliance_text || ""
   );
   const [securitySelfAssessment, setSecuritySelfAssessment] = useState(
-    application.security_self_assessment_text || ""
+    applicationForm.security_self_assessment_text || ""
   );
 
   useEffect(() => {
-    setEthicsConfirmed(application.ethics_confirmed || false);
-    setEthicalDescription(application.ethical_dimension_description || "");
-    setComplianceText(application.compliance_text || "");
-    setSecuritySelfAssessment(application.security_self_assessment_text || "");
-  }, [application]);
+    setEthicsConfirmed(applicationForm.ethics_confirmed || false);
+    setEthicalDescription(applicationForm.ethical_dimension_description || "");
+    setComplianceText(applicationForm.compliance_text || "");
+    setSecuritySelfAssessment(applicationForm.security_self_assessment_text || "");
+  }, [applicationForm]);
 
   const handleChange = () => {
-    updateApplicationField("ethics_confirmed", ethicsConfirmed);
-    updateApplicationField("ethical_dimension_description", ethicalDescription);
-    updateApplicationField("compliance_text", complianceText);
-    updateApplicationField(
+    updateApplicationFormField("ethics_confirmed", ethicsConfirmed);
+    updateApplicationFormField("ethical_dimension_description", ethicalDescription);
+    updateApplicationFormField("compliance_text", complianceText);
+    updateApplicationFormField(
       "security_self_assessment_text",
       securitySelfAssessment
     );

--- a/frontend/src/types/applicationForm.types.ts
+++ b/frontend/src/types/applicationForm.types.ts
@@ -1,0 +1,8 @@
+export interface ApplicationFormCreate {
+  application_id: string;
+  [key: string]: any;
+}
+
+export interface ApplicationForm extends ApplicationFormCreate {
+  id: string;
+}


### PR DESCRIPTION
## Summary
- add API helpers for application forms
- store and fetch ApplicationForm in provider
- create ApplicationForm when creating Application
- persist form values via updateApplicationFormField
- update application step pages to use new form helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6855a6f2d140832caa9b0cfc99cfc036