### PR TITLE
Add centralized API index

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,0 +1,7 @@
+export * from './auth';
+export * from './calls';
+export * from './applications';
+export * from './applicationForms';
+export * from './mobilityEntries';
+export * from './reviews';
+export * from './users';

--- a/frontend/src/context/ApplicationProvider.tsx
+++ b/frontend/src/context/ApplicationProvider.tsx
@@ -9,19 +9,19 @@ import {
   patchApplication,
   getApplication,
   getApplicationAttachments,
-} from "../api/applications";
+} from "../api";
 import {
   createApplicationForm as apiCreateApplicationForm,
   getApplicationForm as apiGetApplicationForm,
   updateApplicationForm as apiUpdateApplicationForm,
-} from "../api/applicationForms";
+} from "../api";
 import {
   getMobilityEntries as apiGetMobilityEntries,
   createMobilityEntry as apiCreateMobilityEntry,
   updateMobilityEntry as apiUpdateMobilityEntry,
   deleteMobilityEntry as apiDeleteMobilityEntry,
-} from "../api/mobilityEntries";
-import { getCall } from "../api/calls";
+} from "../api";
+import { getCall } from "../api";
 import { Call } from "../types/global";
 import { Attachment } from "../types/application";
 import type { MobilityEntry, MobilityEntryInput } from "../types/mobility.types";

--- a/frontend/src/context/AuthProvider.tsx
+++ b/frontend/src/context/AuthProvider.tsx
@@ -1,5 +1,5 @@
 import { createContext, ReactNode, useContext, useEffect, useState } from "react";
-import { login as apiLogin, register as apiRegister } from "../api/auth";
+import { login as apiLogin, register as apiRegister } from "../api";
 
 interface AuthState {
   token: string | null;

--- a/frontend/src/pages/AdminUserManagementPage.tsx
+++ b/frontend/src/pages/AdminUserManagementPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Input } from "../components/ui/Input";
 import { Button } from "../components/ui/Button";
 import { UserRole } from "../types/global";
-import { createUser, listUsers } from "../api/users";
+import { createUser, listUsers } from "../api";
 import { useToast } from "../context/ToastProvider";
 
 interface UserItem {

--- a/frontend/src/pages/CallApplicationsPage.tsx
+++ b/frontend/src/pages/CallApplicationsPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useToast } from "../context/ToastProvider";
-import { getApplicationsByCall } from "../api/applications";
+import { getApplicationsByCall } from "../api";
 
 interface Application {
   id: string;

--- a/frontend/src/pages/CallDetailPage.tsx
+++ b/frontend/src/pages/CallDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { useToast } from "../context/ToastProvider";
-import { getCall } from "../api/calls";
+import { getCall } from "../api";
 import { Call } from "../types/global";
 import { Button } from "../components/ui/Button";
 import { useAuth } from "../context/AuthProvider";

--- a/frontend/src/pages/CallFormPage.tsx
+++ b/frontend/src/pages/CallFormPage.tsx
@@ -2,7 +2,7 @@ import { FormEvent, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Input } from "../components/ui/Input";
 import { Button } from "../components/ui/Button";
-import { createCall, updateCall, getCall, getCalls } from "../api/calls";
+import { createCall, updateCall, getCall, getCalls } from "../api";
 import { CallStatus, Call } from "../types/global";
 import type { CallInput } from "../types/calls.types";
 import { useToast } from "../context/ToastProvider";

--- a/frontend/src/pages/CallManagementPage.tsx
+++ b/frontend/src/pages/CallManagementPage.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate } from "react-router-dom";
 import { Button } from "../components/ui/Button";
 import Table from "../components/ui/Table";
 import ConfirmModal from "../components/ui/ConfirmModal";
-import { getCalls, deleteCall } from "../api/calls";
+import { getCalls, deleteCall } from "../api";
 import { Call, UserRole } from "../types/global";
 import { useAuth } from "../context/AuthProvider";
 

--- a/frontend/src/pages/CallPage.tsx
+++ b/frontend/src/pages/CallPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { useToast } from "../context/ToastProvider";
 import { useAuth } from "../context/AuthProvider";
-import { getCalls } from "../api/calls";
+import { getCalls } from "../api";
 import { UserRole } from "../types/global";
 import type { Call } from "../types/global";
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import Card from "../components/ui/Card";
-import { getApplications } from "../api/applications";
-import { getCalls } from "../api/calls";
+import { getApplications } from "../api";
+import { getCalls } from "../api";
 
 export default function DashboardPage() {
   const [stats, setStats] = useState({ calls: 0, applications: 0 });

--- a/frontend/src/pages/MyApplicationsPage.tsx
+++ b/frontend/src/pages/MyApplicationsPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { getMyApplications } from "../api/applications";
-import { getCall } from "../api/calls";
+import { getMyApplications } from "../api";
+import { getCall } from "../api";
 import { useToast } from "../context/ToastProvider";
 
 interface Application {

--- a/frontend/src/pages/PasswordResetPage.tsx
+++ b/frontend/src/pages/PasswordResetPage.tsx
@@ -3,7 +3,7 @@ import Navbar from "../components/layout/Navbar";
 import { Input } from "../components/ui/Input";
 import { Button } from "../components/ui/Button";
 import { useToast } from "../context/ToastProvider";
-import { requestPasswordReset } from "../api/auth";
+import { requestPasswordReset } from "../api";
 
 export default function PasswordResetPage() {
   const { show } = useToast();

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -5,8 +5,8 @@ import { Input } from "../components/ui/Input";
 import { Button } from "../components/ui/Button";
 import { useToast } from "../context/ToastProvider";
 import type { Attachment, ReviewReport, Review } from "../types/reviews.types";
-import { getReviewReport, createReviewReport } from "../api/reviews";
-import { getApplicationAttachments } from "../api/applications";
+import { getReviewReport, createReviewReport } from "../api";
+import { getApplicationAttachments } from "../api";
 
 
 export default function ReviewPage() {

--- a/frontend/src/pages/ReviewerPage.tsx
+++ b/frontend/src/pages/ReviewerPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { useToast } from "../context/ToastProvider";
-import { getReviewReports } from "../api/reviews";
+import { getReviewReports } from "../api";
 import type { ReviewReport } from "../types/reviews.types";
 
 export default function ReviewerPage() {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Input } from "../components/ui/Input";
 import { Button } from "../components/ui/Button";
-import { getUser, updateUser } from "../api/users";
+import { getUser, updateUser } from "../api";
 import { useAuth } from "../context/AuthProvider";
 import { useToast } from "../context/ToastProvider";
 


### PR DESCRIPTION
## Summary
- create `frontend/src/api/index.ts` and re-export API modules
- update API imports across the codebase to use `../api`

## Testing
- `npm test --silent` *(fails: no tests defined)*
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6855d04e0d84832c815b3b5bbddaddb5