### PR TITLE
Add typed API modules

### DIFF
--- a/frontend/src/api/applicationForms.ts
+++ b/frontend/src/api/applicationForms.ts
@@ -1,10 +1,10 @@
 import { apiFetch } from "../lib/api";
 import type {
   ApplicationForm,
-  ApplicationFormCreate,
-} from "../types/applicationForm.types";
+  ApplicationFormInput,
+} from "../types/application_forms";
 
-export function createApplicationForm(data: ApplicationFormCreate) {
+export function createApplicationForm(data: ApplicationFormInput) {
   return apiFetch("/application_forms", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -16,10 +16,18 @@ export function getApplicationForm(id: string) {
   return apiFetch(`/application_forms/${id}`) as Promise<ApplicationForm>;
 }
 
-export function updateApplicationForm(id: string, data: ApplicationFormCreate) {
+export function getApplicationForms() {
+  return apiFetch(`/application_forms`) as Promise<ApplicationForm[]>;
+}
+
+export function updateApplicationForm(id: string, data: ApplicationFormInput) {
   return apiFetch(`/application_forms/${id}`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
   }) as Promise<ApplicationForm>;
+}
+
+export function deleteApplicationForm(id: string) {
+  return apiFetch(`/application_forms/${id}`, { method: "DELETE" });
 }

--- a/frontend/src/api/applicationInfos.ts
+++ b/frontend/src/api/applicationInfos.ts
@@ -1,0 +1,30 @@
+import { apiFetch } from "../lib/api";
+import type { ApplicationInfo, ApplicationInfoInput } from "../types/application_info";
+
+export function getApplicationInfos() {
+  return apiFetch(`/application_infos`) as Promise<ApplicationInfo[]>;
+}
+
+export function getApplicationInfo(id: string) {
+  return apiFetch(`/application_infos/${id}`) as Promise<ApplicationInfo>;
+}
+
+export function createApplicationInfo(data: ApplicationInfoInput) {
+  return apiFetch(`/application_infos`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  }) as Promise<ApplicationInfo>;
+}
+
+export function updateApplicationInfo(id: string, data: ApplicationInfoInput) {
+  return apiFetch(`/application_infos/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  }) as Promise<ApplicationInfo>;
+}
+
+export function deleteApplicationInfo(id: string) {
+  return apiFetch(`/application_infos/${id}`, { method: "DELETE" });
+}

--- a/frontend/src/api/applications.ts
+++ b/frontend/src/api/applications.ts
@@ -4,8 +4,10 @@ import type {
   CreateApplicationResponse,
   UploadAttachmentResponse,
   MyApplication,
+  Application,
+  ApplicationInput,
 } from "../types/applications.types";
-import type { Attachment } from "../types/reviews.types";
+import type { Attachment } from "../types/attachments";
 
 export function createApplication(callId: string) {
   const body: CreateApplicationRequest = { call_id: callId };
@@ -35,36 +37,36 @@ export function uploadCV(applicationId: string, file: File) {
 }
 
 export function getApplications() {
-  return apiFetch(`/applications`) as Promise<any[]>;
+  return apiFetch(`/applications`) as Promise<Application[]>;
 }
 
 export function getApplicationsByCall(callId: string) {
   const query = `?call_id=${encodeURIComponent(callId)}`;
-  return apiFetch(`/applications${query}`) as Promise<any[]>;
+  return apiFetch(`/applications${query}`) as Promise<Application[]>;
 }
 
 export function getApplication(id: string) {
-  return apiFetch(`/applications/${id}`) as Promise<any>;
+  return apiFetch(`/applications/${id}`) as Promise<Application>;
 }
 
 export function getMyApplications() {
   return apiFetch(`/applications/me`) as Promise<MyApplication[]>;
 }
 
-export function updateApplication(id: string, data: Record<string, unknown>) {
+export function updateApplication(id: string, data: ApplicationInput) {
   return apiFetch(`/applications/${id}`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
-  });
+  }) as Promise<Application>;
 }
 
-export function patchApplication(id: string, data: Record<string, unknown>) {
+export function patchApplication(id: string, data: Partial<ApplicationInput>) {
   return apiFetch(`/applications/${id}`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
-  });
+  }) as Promise<Application>;
 }
 
 export function getApplicationAttachments(id: string) {
@@ -77,4 +79,8 @@ export function deleteAttachment(id: string) {
 
 export function confirmAttachment(id: string) {
   return apiFetch(`/attachments/${id}/confirm`, { method: "PATCH" });
+}
+
+export function deleteApplication(id: string) {
+  return apiFetch(`/applications/${id}`, { method: "DELETE" });
 }

--- a/frontend/src/api/attachments.ts
+++ b/frontend/src/api/attachments.ts
@@ -1,0 +1,38 @@
+import { apiFetch } from "../lib/api";
+import type { Attachment, AttachmentInput } from "../types/attachments";
+
+export function getAttachments() {
+  return apiFetch(`/attachments`) as Promise<Attachment[]>;
+}
+
+export function getAttachment(id: string) {
+  return apiFetch(`/attachments/${id}`) as Promise<Attachment>;
+}
+
+export function getAttachmentsByApplication(applicationId: string) {
+  return apiFetch(`/attachments/application/${applicationId}`) as Promise<Attachment[]>;
+}
+
+export function createAttachment(data: AttachmentInput) {
+  return apiFetch(`/attachments`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  }) as Promise<Attachment>;
+}
+
+export function updateAttachment(id: string, data: AttachmentInput) {
+  return apiFetch(`/attachments/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  }) as Promise<Attachment>;
+}
+
+export function confirmAttachment(id: string) {
+  return apiFetch(`/attachments/${id}/confirm`, { method: "PATCH" }) as Promise<Attachment>;
+}
+
+export function deleteAttachment(id: string) {
+  return apiFetch(`/attachments/${id}`, { method: "DELETE" });
+}

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -2,6 +2,8 @@ export * from './auth';
 export * from './calls';
 export * from './applications';
 export * from './applicationForms';
+export * from './applicationInfos';
+export * from './attachments';
 export * from './mobilityEntries';
 export * from './reviews';
 export * from './users';

--- a/frontend/src/components/ui/DocumentList.tsx
+++ b/frontend/src/components/ui/DocumentList.tsx
@@ -1,6 +1,6 @@
 
 import { useState } from "react";
-import { Attachment } from "../../types/application";
+import { Attachment } from "../../types/attachments";
 import ConfirmModal from "./ConfirmModal";
 import { apiFetch } from "../../lib/api";
 

--- a/frontend/src/context/ApplicationProvider.tsx
+++ b/frontend/src/context/ApplicationProvider.tsx
@@ -23,7 +23,7 @@ import {
 } from "../api";
 import { getCall } from "../api";
 import { Call } from "../types/global";
-import { Attachment } from "../types/application";
+import { Attachment } from "../types/attachments";
 import type { MobilityEntry, MobilityEntryInput } from "../types/mobility.types";
 import { useToast } from "./ToastProvider";
 import { ApiError } from "../lib/api";

--- a/frontend/src/types/application.ts
+++ b/frontend/src/types/application.ts
@@ -1,5 +1,0 @@
-export interface Attachment {
-  id: string;
-  doc_name: string;
-  field_name?: string;
-}

--- a/frontend/src/types/applicationForm.types.ts
+++ b/frontend/src/types/applicationForm.types.ts
@@ -1,8 +1,0 @@
-export interface ApplicationFormCreate {
-  application_id: string;
-  [key: string]: any;
-}
-
-export interface ApplicationForm extends ApplicationFormCreate {
-  id: string;
-}

--- a/frontend/src/types/application_forms.ts
+++ b/frontend/src/types/application_forms.ts
@@ -1,0 +1,50 @@
+export interface ApplicationFormInput {
+  application_id?: string;
+  applicant_name?: string | null;
+  project_number?: string | null;
+  project_title?: string | null;
+  title?: string | null;
+  surname?: string | null;
+  first_name?: string | null;
+  year_of_birth?: number | null;
+  nationality?: string | null;
+  organisation?: string | null;
+  university?: string | null;
+  department?: string | null;
+  town_or_city?: string | null;
+  country?: string | null;
+  current_position?: string | null;
+  gender?: string | null;
+  passport_or_id_path?: string | null;
+  phd_certificate_path?: string | null;
+  acronym?: string | null;
+  keywords?: string | null;
+  abstract?: string | null;
+  selected_supervisor?: string | null;
+  has_secondment?: boolean | null;
+  selected_from_db?: boolean | null;
+  institution_name?: string | null;
+  loc_document_path?: string | null;
+  doctoral_discipline?: string | null;
+  doctoral_thesis_title?: string | null;
+  doctoral_awarding_institution?: string | null;
+  doctoral_award_date?: string | null;
+  current_institution?: string | null;
+  current_department?: string | null;
+  current_institution_town?: string | null;
+  current_institution_country?: string | null;
+  current_phone_number?: string | null;
+  agreed?: boolean | null;
+  uploaded_proposal_path?: string | null;
+  uploaded_cv_path?: string | null;
+  ethics_confirmed?: boolean | null;
+  ethical_dimension_description?: string | null;
+  compliance_text?: string | null;
+  security_self_assessment_text?: string | null;
+}
+
+export interface ApplicationForm extends ApplicationFormInput {
+  id: string;
+  created_at?: string | null;
+  updated_at?: string | null;
+}

--- a/frontend/src/types/application_info.ts
+++ b/frontend/src/types/application_info.ts
@@ -1,0 +1,10 @@
+export interface ApplicationInfoInput {
+  application_id?: string;
+  applicant_name?: string | null;
+  project_number?: string | null;
+  project_title?: string | null;
+}
+
+export interface ApplicationInfo extends ApplicationInfoInput {
+  id: string;
+}

--- a/frontend/src/types/applications.types.ts
+++ b/frontend/src/types/applications.types.ts
@@ -1,3 +1,5 @@
+import type { ApplicationStatus } from './global';
+
 export interface CreateApplicationRequest {
   call_id: string;
 }
@@ -11,6 +13,19 @@ export interface UploadAttachmentResponse {
   id: string;
   doc_name: string;
   field_name?: string;
+}
+
+export interface ApplicationInput {
+  call_id?: string | null;
+  user_id?: string | null;
+  status?: ApplicationStatus;
+  completed_steps?: string[] | null;
+}
+
+export interface Application extends ApplicationInput {
+  id: string;
+  created_at?: string | null;
+  updated_at?: string | null;
 }
 
 export interface MyApplication {

--- a/frontend/src/types/attachments.ts
+++ b/frontend/src/types/attachments.ts
@@ -1,0 +1,12 @@
+export interface AttachmentInput {
+  application_id?: string;
+  doc_name?: string | null;
+  field_name?: string | null;
+  file_path?: string | null;
+  confirmed?: boolean | null;
+}
+
+export interface Attachment extends AttachmentInput {
+  id: string;
+  uploaded_at?: string | null;
+}

--- a/frontend/src/types/global.ts
+++ b/frontend/src/types/global.ts
@@ -17,3 +17,5 @@ export interface Call {
 }
 
 export type CallStatus = 'DRAFT' | 'PUBLISHED' | 'CLOSED' | 'ARCHIVED';
+
+export type ApplicationStatus = 'DRAFT' | 'SUBMITTED' | 'CLOSED' | 'ARCHIVED';

--- a/frontend/src/types/reviews.types.ts
+++ b/frontend/src/types/reviews.types.ts
@@ -1,13 +1,5 @@
 
-export interface Attachment {
-  id: string;
-  doc_name: string;
-  field_name?: string;
-  application_id?: string;
-  file_path?: string;
-  confirmed?: boolean;
-  uploaded_at?: string;
-}
+import type { Attachment } from './attachments';
 
 export interface Review {
   excellence_grade: string;


### PR DESCRIPTION
## Summary
- add frontend API modules for attachments and application infos
- enhance application form, application, attachment, and user types
- update global types with ApplicationStatus
- export new API functions in index
- adapt imports for attachments

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6855d6d74a2c832cb203509e4db74c5f