### PR TITLE
Add frontend APIs/types for academic resources

### DIFF
--- a/frontend/src/api/academicPortfolios.ts
+++ b/frontend/src/api/academicPortfolios.ts
@@ -1,0 +1,30 @@
+import { apiFetch } from "../lib/api";
+import type { AcademicPortfolioInput, AcademicPortfolio } from "../types/academicPortfolio.types";
+
+export function createAcademicPortfolio(data: AcademicPortfolioInput) {
+  return apiFetch(`/academic_portfolios`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  }) as Promise<AcademicPortfolio>;
+}
+
+export function getAcademicPortfolio(id: string) {
+  return apiFetch(`/academic_portfolios/${id}`) as Promise<AcademicPortfolio>;
+}
+
+export function listAcademicPortfolios() {
+  return apiFetch(`/academic_portfolios`) as Promise<AcademicPortfolio[]>;
+}
+
+export function updateAcademicPortfolio(id: string, data: AcademicPortfolioInput) {
+  return apiFetch(`/academic_portfolios/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  }) as Promise<AcademicPortfolio>;
+}
+
+export function deleteAcademicPortfolio(id: string) {
+  return apiFetch(`/academic_portfolios/${id}`, { method: "DELETE" });
+}

--- a/frontend/src/api/academicReferences.ts
+++ b/frontend/src/api/academicReferences.ts
@@ -1,0 +1,30 @@
+import { apiFetch } from "../lib/api";
+import type { AcademicReferenceInput, AcademicReference } from "../types/academicReference.types";
+
+export function createAcademicReference(data: AcademicReferenceInput) {
+  return apiFetch(`/academic_references`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  }) as Promise<AcademicReference>;
+}
+
+export function getAcademicReference(id: string) {
+  return apiFetch(`/academic_references/${id}`) as Promise<AcademicReference>;
+}
+
+export function listAcademicReferences() {
+  return apiFetch(`/academic_references`) as Promise<AcademicReference[]>;
+}
+
+export function updateAcademicReference(id: string, data: AcademicReferenceInput) {
+  return apiFetch(`/academic_references/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  }) as Promise<AcademicReference>;
+}
+
+export function deleteAcademicReference(id: string) {
+  return apiFetch(`/academic_references/${id}`, { method: "DELETE" });
+}

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -5,3 +5,8 @@ export * from './applicationForms';
 export * from './mobilityEntries';
 export * from './reviews';
 export * from './users';
+export * from './academicPortfolios';
+export * from './academicReferences';
+export * from './suggestedReferences';
+export * from './supervisors';
+export * from './institutions';

--- a/frontend/src/api/institutions.ts
+++ b/frontend/src/api/institutions.ts
@@ -1,0 +1,30 @@
+import { apiFetch } from "../lib/api";
+import type { InstitutionInput, Institution } from "../types/institution.types";
+
+export function createInstitution(data: InstitutionInput) {
+  return apiFetch(`/institutions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  }) as Promise<Institution>;
+}
+
+export function getInstitution(id: string) {
+  return apiFetch(`/institutions/${id}`) as Promise<Institution>;
+}
+
+export function listInstitutions() {
+  return apiFetch(`/institutions`) as Promise<Institution[]>;
+}
+
+export function updateInstitution(id: string, data: InstitutionInput) {
+  return apiFetch(`/institutions/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  }) as Promise<Institution>;
+}
+
+export function deleteInstitution(id: string) {
+  return apiFetch(`/institutions/${id}`, { method: "DELETE" });
+}

--- a/frontend/src/api/suggestedReferences.ts
+++ b/frontend/src/api/suggestedReferences.ts
@@ -1,0 +1,30 @@
+import { apiFetch } from "../lib/api";
+import type { SuggestedReferenceInput, SuggestedReference } from "../types/suggestedReference.types";
+
+export function createSuggestedReference(data: SuggestedReferenceInput) {
+  return apiFetch(`/suggested_references`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  }) as Promise<SuggestedReference>;
+}
+
+export function getSuggestedReference(id: string) {
+  return apiFetch(`/suggested_references/${id}`) as Promise<SuggestedReference>;
+}
+
+export function listSuggestedReferences() {
+  return apiFetch(`/suggested_references`) as Promise<SuggestedReference[]>;
+}
+
+export function updateSuggestedReference(id: string, data: SuggestedReferenceInput) {
+  return apiFetch(`/suggested_references/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  }) as Promise<SuggestedReference>;
+}
+
+export function deleteSuggestedReference(id: string) {
+  return apiFetch(`/suggested_references/${id}`, { method: "DELETE" });
+}

--- a/frontend/src/api/supervisors.ts
+++ b/frontend/src/api/supervisors.ts
@@ -1,0 +1,30 @@
+import { apiFetch } from "../lib/api";
+import type { SupervisorInput, Supervisor } from "../types/supervisor.types";
+
+export function createSupervisor(data: SupervisorInput) {
+  return apiFetch(`/supervisors`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  }) as Promise<Supervisor>;
+}
+
+export function getSupervisor(id: string) {
+  return apiFetch(`/supervisors/${id}`) as Promise<Supervisor>;
+}
+
+export function listSupervisors() {
+  return apiFetch(`/supervisors`) as Promise<Supervisor[]>;
+}
+
+export function updateSupervisor(id: string, data: SupervisorInput) {
+  return apiFetch(`/supervisors/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  }) as Promise<Supervisor>;
+}
+
+export function deleteSupervisor(id: string) {
+  return apiFetch(`/supervisors/${id}`, { method: "DELETE" });
+}

--- a/frontend/src/types/academicPortfolio.types.ts
+++ b/frontend/src/types/academicPortfolio.types.ts
@@ -1,0 +1,9 @@
+export interface AcademicPortfolioInput {
+  application_form_id?: string;
+  field_name?: string;
+  field_value?: string;
+}
+
+export interface AcademicPortfolio extends AcademicPortfolioInput {
+  id: string;
+}

--- a/frontend/src/types/academicReference.types.ts
+++ b/frontend/src/types/academicReference.types.ts
@@ -1,0 +1,11 @@
+export interface AcademicReferenceInput {
+  application_form_id?: string;
+  ref_type?: string;
+  title?: string;
+  year?: number;
+  doi?: string;
+}
+
+export interface AcademicReference extends AcademicReferenceInput {
+  id: string;
+}

--- a/frontend/src/types/institution.types.ts
+++ b/frontend/src/types/institution.types.ts
@@ -1,0 +1,9 @@
+export interface InstitutionInput {
+  name: string;
+  country?: string;
+  website?: string;
+}
+
+export interface Institution extends InstitutionInput {
+  id: string;
+}

--- a/frontend/src/types/suggestedReference.types.ts
+++ b/frontend/src/types/suggestedReference.types.ts
@@ -1,0 +1,15 @@
+export interface SuggestedReferenceInput {
+  application_form_id?: string;
+  name_surname: string;
+  institution: string;
+  department?: string;
+  country?: string;
+  position?: string;
+  phone_number?: string;
+  email?: string;
+  reason?: string;
+}
+
+export interface SuggestedReference extends SuggestedReferenceInput {
+  id: string;
+}

--- a/frontend/src/types/supervisor.types.ts
+++ b/frontend/src/types/supervisor.types.ts
@@ -1,0 +1,11 @@
+export interface SupervisorInput {
+  institution_id?: string;
+  name_surname: string;
+  email?: string;
+  phone?: string;
+  department?: string;
+}
+
+export interface Supervisor extends SupervisorInput {
+  id: string;
+}


### PR DESCRIPTION
## Summary
- implement academic portfolio API client and types
- implement academic reference API client and types
- implement suggested reference API client and types
- implement supervisor API client and types
- implement institution API client and types
- export new API modules

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6855d6ff92d8832caa12ad559dac07d5