### PR TITLE
Add review_reports and mobility_entries API modules

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -2,6 +2,6 @@ export * from './auth';
 export * from './calls';
 export * from './applications';
 export * from './applicationForms';
-export * from './mobilityEntries';
-export * from './reviews';
+export * from './mobility_entries';
+export * from './review_reports';
 export * from './users';

--- a/frontend/src/api/mobility_entries.ts
+++ b/frontend/src/api/mobility_entries.ts
@@ -1,0 +1,36 @@
+import { apiFetch } from "../lib/api";
+import type { MobilityEntry } from "../types/mobility_entries";
+
+export function getMobilityEntry(id: string) {
+  return apiFetch(`/mobility_entries/${id}`) as Promise<MobilityEntry>;
+}
+
+export function listMobilityEntries() {
+  return apiFetch(`/mobility_entries`) as Promise<MobilityEntry[]>;
+}
+
+export function getMobilityEntriesByApplicationForm(applicationFormId: string) {
+  return apiFetch(
+    `/mobility_entries/application_form/${applicationFormId}`
+  ) as Promise<MobilityEntry[]>;
+}
+
+export function createMobilityEntry(data: MobilityEntry) {
+  return apiFetch(`/mobility_entries`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  }) as Promise<MobilityEntry>;
+}
+
+export function updateMobilityEntry(id: string, data: MobilityEntry) {
+  return apiFetch(`/mobility_entries/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  }) as Promise<MobilityEntry>;
+}
+
+export function deleteMobilityEntry(id: string) {
+  return apiFetch(`/mobility_entries/${id}`, { method: "DELETE" });
+}

--- a/frontend/src/api/review_reports.ts
+++ b/frontend/src/api/review_reports.ts
@@ -1,0 +1,30 @@
+import { apiFetch } from "../lib/api";
+import type { ReviewReport } from "../types/review_reports";
+
+export function getReviewReport(id: string) {
+  return apiFetch(`/review_reports/${id}`) as Promise<ReviewReport>;
+}
+
+export function listReviewReports() {
+  return apiFetch(`/review_reports`) as Promise<ReviewReport[]>;
+}
+
+export function createReviewReport(data: ReviewReport) {
+  return apiFetch(`/review_reports`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  }) as Promise<ReviewReport>;
+}
+
+export function updateReviewReport(id: string, data: ReviewReport) {
+  return apiFetch(`/review_reports/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  }) as Promise<ReviewReport>;
+}
+
+export function deleteReviewReport(id: string) {
+  return apiFetch(`/review_reports/${id}`, { method: "DELETE" });
+}

--- a/frontend/src/types/mobility_entries.ts
+++ b/frontend/src/types/mobility_entries.ts
@@ -1,0 +1,11 @@
+export interface MobilityEntryInput {
+  application_form_id?: string | null;
+  from_date: string;
+  to_date: string;
+  organisation?: string | null;
+  country?: string | null;
+}
+
+export interface MobilityEntry extends MobilityEntryInput {
+  id: string;
+}

--- a/frontend/src/types/review_reports.ts
+++ b/frontend/src/types/review_reports.ts
@@ -1,0 +1,32 @@
+export interface ReviewReportBase {
+  call_id?: string | null;
+  application_id?: string | null;
+  reviewer_id?: string | null;
+  project_number?: string | null;
+  applicant_name?: string | null;
+  project_type?: string | null;
+  project_title?: string | null;
+  excellence_grade?: number | null;
+  impact_grade?: number | null;
+  implementation_grade?: number | null;
+  excellence_comments?: Record<string, unknown> | null;
+  impact_comments?: Record<string, unknown> | null;
+  implementation_comments?: Record<string, unknown> | null;
+  raises_ethics_issues?: boolean | null;
+  ethics_details?: string | null;
+  total_score?: number | null;
+  total_weighted_score?: number | null;
+  normalized_score?: number | null;
+  additional_comments?: string | null;
+}
+
+export interface ReviewReportCreate extends ReviewReportBase {}
+
+export interface ReviewReport extends ReviewReportBase {
+  id: string;
+  created_at?: string | null;
+}
+
+export interface SubmitReviewResponse {
+  id: string;
+}


### PR DESCRIPTION
## Summary
- implement API helper modules for `review_reports` and `mobility_entries`
- add corresponding TypeScript types
- re-export new modules from central API index

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6855d708badc832cba2f38a1f7ee11bb