### PR TITLE
Restore core API utilities and modules

### DIFF
--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,0 +1,26 @@
+import { apiFetch } from "../lib/api";
+import type { LoginData, RegisterData, LoginResponse, RegisterResponse } from "../types/auth.types";
+
+export function login(data: LoginData) {
+  return apiFetch("/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  }) as Promise<LoginResponse>;
+}
+
+export function register(data: RegisterData) {
+  return apiFetch("/auth/register", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  }) as Promise<RegisterResponse>;
+}
+
+export function requestPasswordReset(email: string) {
+  return apiFetch("/auth/password_reset", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email }),
+  });
+}

--- a/frontend/src/api/calls.ts
+++ b/frontend/src/api/calls.ts
@@ -1,0 +1,31 @@
+import { apiFetch } from "../lib/api";
+import type { GetCallsResponse, GetCallResponse, CallInput } from "../types/calls.types";
+
+export function getCalls(status?: string) {
+  const query = status ? `?status=${encodeURIComponent(status)}` : "";
+  return apiFetch(`/call${query}`) as Promise<GetCallsResponse>;
+}
+
+export function getCall(id: string) {
+  return apiFetch(`/call/${id}`) as Promise<GetCallResponse>;
+}
+
+export function createCall(data: CallInput) {
+  return apiFetch(`/call`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export function updateCall(id: string, data: CallInput) {
+  return apiFetch(`/call/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export function deleteCall(id: string) {
+  return apiFetch(`/call/${id}`, { method: "DELETE" });
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,32 @@
+const API_BASE = import.meta.env.VITE_API_BASE || "http://localhost:8000";
+
+export class ApiError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
+export async function apiFetch(path: string, options: RequestInit & { asBlob?: boolean } = {}) {
+  const token = localStorage.getItem("token");
+  const headers = new Headers(options.headers);
+  if (token) headers.set("Authorization", `Bearer ${token}`);
+
+  const res = await fetch(`${API_BASE}${path}`, { ...options, headers });
+  if (!res.ok) {
+    let message = res.statusText;
+    try {
+      const data = await res.clone().json();
+      const detail = (data as any).detail;
+      message = typeof detail === "string" ? detail : JSON.stringify(detail || (data as any).message || message);
+    } catch {
+      const text = await res.text().catch(() => null);
+      if (text) message = text;
+    }
+    throw new ApiError(res.status, message);
+  }
+  if (res.status === 204) return null;
+  if (options.asBlob) return res.blob();
+  return res.json();
+}

--- a/frontend/src/types/auth.types.ts
+++ b/frontend/src/types/auth.types.ts
@@ -1,0 +1,20 @@
+export interface LoginData {
+  email: string;
+  password: string;
+}
+
+export interface RegisterData {
+  email: string;
+  password: string;
+  first_name?: string;
+  last_name?: string;
+  role?: string;
+}
+
+export interface LoginResponse {
+  access_token: string;
+}
+
+export interface RegisterResponse {
+  id?: string;
+}

--- a/frontend/src/types/calls.types.ts
+++ b/frontend/src/types/calls.types.ts
@@ -1,0 +1,12 @@
+import type { Call, CallStatus } from './global';
+
+export interface CallInput {
+  title: string;
+  description?: string | null;
+  status?: CallStatus;
+  start_date?: string | null;
+  end_date?: string | null;
+}
+
+export type GetCallsResponse = Call[];
+export type GetCallResponse = Call;

--- a/frontend/src/types/global.ts
+++ b/frontend/src/types/global.ts
@@ -1,0 +1,19 @@
+export enum UserRole {
+  applicant = 'applicant',
+  reviewer = 'reviewer',
+  admin = 'admin',
+  super_admin = 'super_admin',
+}
+
+export interface Call {
+  id: string;
+  title?: string;
+  description?: string | null;
+  status?: CallStatus;
+  start_date?: string | null;
+  end_date?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export type CallStatus = 'DRAFT' | 'PUBLISHED' | 'CLOSED' | 'ARCHIVED';


### PR DESCRIPTION
## Summary
- add reusable `apiFetch` helper with `ApiError`
- reimplement auth and call API modules
- restore supporting types for auth and call resources

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6855de58e31c832cb0f4b0c1dfb54e15