### PR TITLE
Refactor first application steps

### DIFF
--- a/frontend/src/pages/calls/Step1_CallInfo.tsx
+++ b/frontend/src/pages/calls/Step1_CallInfo.tsx
@@ -3,30 +3,41 @@ import { useNavigate } from "react-router-dom";
 import { Button } from "../../components/ui/Button";
 import { useToast } from "../../context/ToastProvider";
 import { useApplication } from "../../context/ApplicationProvider";
+import {
+  createApplication,
+  createApplicationForm,
+  patchApplication,
+} from "../../api";
+import type { Application } from "../../types/applications";
 
 export default function Step1_CallInfo() {
-  const { call, createApplication, applicationId, completeStep } = useApplication();
+  const { call, applicationId } = useApplication();
   const { show } = useToast();
   const navigate = useNavigate();
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+  const [application, setApplication] = useState<Application | null>(null);
 
   useEffect(() => {
+    // If an application already exists, mark this step as completed on load
     if (applicationId) {
-      completeStep("step1");
+      patchApplication(applicationId, {
+        completed_steps: ["step1"],
+      }).catch(() => {});
     }
   }, [applicationId]);
 
   const handleCreate = async () => {
+    if (!call?.id) return;
     setLoading(true);
     setError(null);
     try {
-      const id = await createApplication();
-      if (id) {
-        await completeStep("step1");
-        show("Application created");
-        navigate("../step2");
-      }
+      const app: Application = await createApplication({ call_id: call.id });
+      setApplication(app);
+      await createApplicationForm({ application_id: app.id });
+      await patchApplication(app.id, { completed_steps: ["step1"] });
+      show("Application created");
+      navigate("../step2");
     } catch (err) {
       setError((err as Error).message);
       show("Failed to create application");


### PR DESCRIPTION
## Summary
- fetch and update application data directly from API in `Step1_CallInfo` and `Step2_ApplicantInfo`
- type local state with shared interfaces
- show toast messages on API success or failure

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6856fa1bc158832c9e2de02c97666a5a