### PR TITLE
Use shared Application type

### DIFF
--- a/frontend/src/pages/user/admin/CallApplicationsPage.tsx
+++ b/frontend/src/pages/user/admin/CallApplicationsPage.tsx
@@ -1,11 +1,8 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useToast } from "../../../context/ToastProvider";
-import { getApplicationsByCall } from "../../../api";
-
-interface Application {
-  id: string;
-}
+import { getApplications } from "../../../api";
+import type { Application } from "../../../types/applications";
 
 export default function CallApplicationsPage() {
   const { callId } = useParams<{ callId: string }>();
@@ -18,7 +15,7 @@ export default function CallApplicationsPage() {
     if (!callId) return;
     setLoading(true);
     setError(null);
-    getApplicationsByCall(callId)
+    getApplications(callId)
       .then((data) => {
         setApps(data);
         if (data.length > 0) {


### PR DESCRIPTION
## Summary
- use Application type from `src/types/applications` in CallApplicationsPage
- use `getApplications` call scoped by `callId`

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6856fac270e0832cb4bc96a0a1d1a8fd