### PR TITLE
Replace UserItem with shared User type

### DIFF
--- a/frontend/src/pages/user/admin/AdminUserManagementPage.tsx
+++ b/frontend/src/pages/user/admin/AdminUserManagementPage.tsx
@@ -4,18 +4,10 @@ import { Button } from "../../../components/ui/Button";
 import { UserRole } from "../../../types/global";
 import { createUser, listUsers } from "../../../api";
 import { useToast } from "../../../context/ToastProvider";
-
-interface UserItem {
-  id: string;
-  email: string;
-  first_name: string;
-  last_name: string;
-  organization?: string | null;
-  role: UserRole;
-}
+import type { User } from "../../../types/users";
 
 export default function AdminUserManagementPage() {
-  const [users, setUsers] = useState<UserItem[]>([]);
+  const [users, setUsers] = useState<User[]>([]);
   const [email, setEmail] = useState("");
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");


### PR DESCRIPTION
## Summary
- switch AdminUserManagementPage to import the shared `User` interface
- drop local `UserItem` type definition

## Testing
- `npm install --silent` *(fails: network unreachable)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6856fac3d6e4832cbc7cc561f1bf2a2c