### PR TITLE
Improve error handling with ApiError

### DIFF
--- a/frontend/src/pages/AdminUserManagementPage.tsx
+++ b/frontend/src/pages/AdminUserManagementPage.tsx
@@ -3,6 +3,7 @@ import { Input } from "../components/ui/Input";
 import { Button } from "../components/ui/Button";
 import { UserRole } from "../types/global";
 import { createUser, listUsers } from "../api";
+import { ApiError } from "../api/api";
 import { useToast } from "../context/ToastProvider";
 
 interface UserItem {
@@ -30,7 +31,11 @@ export default function AdminUserManagementPage() {
         const data = await listUsers();
         setUsers(data);
       } catch (err) {
-        show((err as Error).message);
+        if (err instanceof ApiError) {
+          show(err.message);
+        } else {
+          show((err as Error).message);
+        }
       }
     }
     fetchUsers();
@@ -55,7 +60,11 @@ export default function AdminUserManagementPage() {
       setOrganization("");
       show("User created");
     } catch (err) {
-      show((err as Error).message);
+      if (err instanceof ApiError) {
+        show(err.message);
+      } else {
+        show((err as Error).message);
+      }
     }
   };
 

--- a/frontend/src/pages/CallApplicationsPage.tsx
+++ b/frontend/src/pages/CallApplicationsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useToast } from "../context/ToastProvider";
 import { getApplicationsByCall } from "../api";
+import { ApiError } from "../api/api";
 
 interface Application {
   id: string;
@@ -28,8 +29,13 @@ export default function CallApplicationsPage() {
         }
       })
       .catch((err) => {
-        setError(err.message);
-        show("Failed to load applications");
+        if (err instanceof ApiError) {
+          setError(err.message);
+          show(err.message);
+        } else {
+          setError((err as Error).message);
+          show("Failed to load applications");
+        }
       })
       .finally(() => setLoading(false));
   }, [callId, show]);

--- a/frontend/src/pages/CallDetailPage.tsx
+++ b/frontend/src/pages/CallDetailPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { useToast } from "../context/ToastProvider";
 import { getCall } from "../api";
+import { ApiError } from "../api/api";
 import { Call } from "../types/global";
 import { Button } from "../components/ui/Button";
 import { useAuth } from "../context/AuthProvider";
@@ -24,8 +25,13 @@ export default function CallDetailPage() {
         show("Call loaded");
       })
       .catch((err) => {
-        setError(err.message);
-        show("Failed to load call");
+        if (err instanceof ApiError) {
+          setError(err.message);
+          show(err.message);
+        } else {
+          setError((err as Error).message);
+          show("Failed to load call");
+        }
       })
       .finally(() => setLoading(false));
   }, [callId, show]);

--- a/frontend/src/pages/CallFormPage.tsx
+++ b/frontend/src/pages/CallFormPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { Input } from "../components/ui/Input";
 import { Button } from "../components/ui/Button";
 import { createCall, updateCall, getCall, getCalls } from "../api";
+import { ApiError } from "../api/api";
 import { CallStatus, Call } from "../types/global";
 import type { CallInput } from "../types/calls.types";
 import { useToast } from "../context/ToastProvider";
@@ -36,7 +37,15 @@ export default function CallFormPage() {
           end_date: data.end_date ? data.end_date.substring(0, 10) : "",
         });
       })
-      .catch((err) => setError(err.message))
+      .catch((err) => {
+        if (err instanceof ApiError) {
+          setError(err.message);
+          show(err.message);
+        } else {
+          setError((err as Error).message);
+          show("Failed to load call");
+        }
+      })
       .finally(() => setLoading(false));
   }, [callId]);
 
@@ -83,7 +92,13 @@ export default function CallFormPage() {
       }
       navigate("/call/manage");
     } catch (err) {
-      setError((err as Error).message);
+      if (err instanceof ApiError) {
+        setError(err.message);
+        show(err.message);
+      } else {
+        setError((err as Error).message);
+        show("Failed to save call");
+      }
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/CallManagementPage.tsx
+++ b/frontend/src/pages/CallManagementPage.tsx
@@ -4,8 +4,10 @@ import { Button } from "../components/ui/Button";
 import Table from "../components/ui/Table";
 import ConfirmModal from "../components/ui/ConfirmModal";
 import { getCalls, deleteCall } from "../api";
+import { ApiError } from "../api/api";
 import { Call, UserRole } from "../types/global";
 import { useAuth } from "../context/AuthProvider";
+import { useToast } from "../context/ToastProvider";
 
 export default function CallManagementPage() {
   const [calls, setCalls] = useState<Call[]>([]);
@@ -14,6 +16,7 @@ export default function CallManagementPage() {
   const [confirmId, setConfirmId] = useState<string | null>(null);
   const { role } = useAuth();
   const navigate = useNavigate();
+  const { show } = useToast();
 
   async function load() {
     setLoading(true);
@@ -22,7 +25,13 @@ export default function CallManagementPage() {
       const data = await getCalls();
       setCalls(data);
     } catch (err) {
-      setError((err as Error).message);
+      if (err instanceof ApiError) {
+        setError(err.message);
+        show(err.message);
+      } else {
+        setError((err as Error).message);
+        show("Failed to load calls");
+      }
     } finally {
       setLoading(false);
     }
@@ -39,7 +48,13 @@ export default function CallManagementPage() {
       await deleteCall(id);
       await load();
     } catch (err) {
-      setError((err as Error).message);
+      if (err instanceof ApiError) {
+        setError(err.message);
+        show(err.message);
+      } else {
+        setError((err as Error).message);
+        show("Failed to delete call");
+      }
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/CallPage.tsx
+++ b/frontend/src/pages/CallPage.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { useToast } from "../context/ToastProvider";
 import { useAuth } from "../context/AuthProvider";
 import { getCalls } from "../api";
+import { ApiError } from "../api/api";
 import { UserRole } from "../types/global";
 import type { Call } from "../types/global";
 
@@ -23,8 +24,13 @@ export default function CallPage() {
         setCall(openCall);
       })
       .catch((err) => {
-        setError((err as Error).message);
-        show("Failed to load call");
+        if (err instanceof ApiError) {
+          setError(err.message);
+          show(err.message);
+        } else {
+          setError((err as Error).message);
+          show("Failed to load call");
+        }
       })
       .finally(() => setLoading(false));
   }, [show]);

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -2,11 +2,14 @@ import { useEffect, useState } from "react";
 import Card from "../components/ui/Card";
 import { getApplications } from "../api";
 import { getCalls } from "../api";
+import { ApiError } from "../api/api";
+import { useToast } from "../context/ToastProvider";
 
 export default function DashboardPage() {
   const [stats, setStats] = useState({ calls: 0, applications: 0 });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { show } = useToast();
 
   useEffect(() => {
     async function load() {
@@ -17,7 +20,13 @@ export default function DashboardPage() {
         const apps = await getApplications();
         setStats({ calls: calls.length, applications: apps.length });
       } catch (err) {
-        setError((err as Error).message);
+        if (err instanceof ApiError) {
+          setError(err.message);
+          show(err.message);
+        } else {
+          setError((err as Error).message);
+          show("Failed to load dashboard");
+        }
       } finally {
         setLoading(false);
       }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -6,6 +6,7 @@ import Navbar from "../components/layout/Navbar";
 import { useToast } from "../context/ToastProvider";
 import { useAuth } from "../context/AuthProvider";
 import { UserRole } from "../types/global";
+import { ApiError } from "../api/api";
 
 export default function LoginPage() {
   const { show } = useToast();
@@ -41,9 +42,14 @@ export default function LoginPage() {
         navigate("/");
       }
     } catch (err) {
-      const msg = (err as Error).message || "Login failed";
-      setError(msg);
-      show(msg);
+      if (err instanceof ApiError) {
+        setError(err.message);
+        show(err.message);
+      } else {
+        const msg = (err as Error).message || "Login failed";
+        setError(msg);
+        show(msg);
+      }
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/MyApplicationsPage.tsx
+++ b/frontend/src/pages/MyApplicationsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { getMyApplications } from "../api";
 import { getCall } from "../api";
+import { ApiError } from "../api/api";
 import { useToast } from "../context/ToastProvider";
 
 interface Application {
@@ -43,8 +44,13 @@ export default function MyApplicationsPage() {
         show("Applications loaded");
       })
       .catch((err) => {
-        setError(err.message);
-        show("Failed to load applications");
+        if (err instanceof ApiError) {
+          setError(err.message);
+          show(err.message);
+        } else {
+          setError((err as Error).message);
+          show("Failed to load applications");
+        }
       })
       .finally(() => setLoading(false));
   }, [show]);

--- a/frontend/src/pages/PasswordResetPage.tsx
+++ b/frontend/src/pages/PasswordResetPage.tsx
@@ -4,6 +4,7 @@ import { Input } from "../components/ui/Input";
 import { Button } from "../components/ui/Button";
 import { useToast } from "../context/ToastProvider";
 import { requestPasswordReset } from "../api";
+import { ApiError } from "../api/api";
 
 export default function PasswordResetPage() {
   const { show } = useToast();
@@ -17,8 +18,12 @@ export default function PasswordResetPage() {
       show(
         "If an account exists for that email, instructions have been sent."
       );
-    } catch {
-      show("Failed to send password reset instructions.");
+    } catch (err) {
+      if (err instanceof ApiError) {
+        show(err.message);
+      } else {
+        show("Failed to send password reset instructions.");
+      }
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -5,6 +5,7 @@ import { Button } from "../components/ui/Button";
 import Navbar from "../components/layout/Navbar";
 import { useToast } from "../context/ToastProvider";
 import { useAuth } from "../context/AuthProvider";
+import { ApiError } from "../api/api";
 
 export default function RegisterPage() {
   const { show } = useToast();
@@ -19,8 +20,12 @@ export default function RegisterPage() {
       await register(email, password);
       show("Registration successful! Check your email.");
       navigate("/login");
-    } catch {
-      show("Registration failed. Please try again.");
+    } catch (err) {
+      if (err instanceof ApiError) {
+        show(err.message);
+      } else {
+        show("Registration failed. Please try again.");
+      }
     }
   };
 

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -7,6 +7,7 @@ import { useToast } from "../context/ToastProvider";
 import type { Attachment, ReviewReport, Review } from "../types/reviews.types";
 import { getReviewReport, createReviewReport } from "../api";
 import { getApplicationAttachments } from "../api";
+import { ApiError } from "../api/api";
 
 
 export default function ReviewPage() {
@@ -25,14 +26,26 @@ export default function ReviewPage() {
     if (!reviewId) return;
     getReviewReport(reviewId)
       .then(setReview)
-      .catch((err) => show(err.message));
+      .catch((err) => {
+        if (err instanceof ApiError) {
+          show(err.message);
+        } else {
+          show("Failed to load review");
+        }
+      });
   }, [reviewId, show]);
 
   useEffect(() => {
     if (review?.application_id) {
       getApplicationAttachments(review.application_id)
         .then(setAttachments)
-        .catch((err) => show(err.message));
+        .catch((err) => {
+          if (err instanceof ApiError) {
+            show(err.message);
+          } else {
+            show("Failed to load attachments");
+          }
+        });
     }
   }, [review, show]);
 
@@ -48,12 +61,14 @@ export default function ReviewPage() {
     createReviewReport(data)
       .then(() => show("Review submitted"))
       .catch((err: unknown) => {
-      if (err instanceof Error) {
-        show(err.message);
-      } else {
-        show("An unexpected error occurred");
-      }
-    });
+        if (err instanceof ApiError) {
+          show(err.message);
+        } else if (err instanceof Error) {
+          show(err.message);
+        } else {
+          show("An unexpected error occurred");
+        }
+      });
   }
 
   if (!review) return <div>Loading...</div>;

--- a/frontend/src/pages/ReviewerPage.tsx
+++ b/frontend/src/pages/ReviewerPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { useToast } from "../context/ToastProvider";
 import { getReviewReports } from "../api";
+import { ApiError } from "../api/api";
 import type { ReviewReport } from "../types/reviews.types";
 
 export default function ReviewerPage() {
@@ -19,8 +20,13 @@ export default function ReviewerPage() {
         show("Reviews loaded");
       })
       .catch((err) => {
-        setError(err.message);
-        show("Failed to load reviews");
+        if (err instanceof ApiError) {
+          setError(err.message);
+          show(err.message);
+        } else {
+          setError((err as Error).message);
+          show("Failed to load reviews");
+        }
       })
       .finally(() => setLoading(false));
   }, [show]);

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Input } from "../components/ui/Input";
 import { Button } from "../components/ui/Button";
 import { getUser, updateUser } from "../api";
+import { ApiError } from "../api/api";
 import { useAuth } from "../context/AuthProvider";
 import { useToast } from "../context/ToastProvider";
 
@@ -19,7 +20,13 @@ export default function SettingsPage() {
         setFirstName(u.first_name);
         setLastName(u.last_name);
       })
-      .catch(() => {});
+      .catch((err) => {
+        if (err instanceof ApiError) {
+          show(err.message);
+        } else {
+          show("Failed to load settings");
+        }
+      });
   }, [userId]);
 
   const handleSubmit = async () => {
@@ -31,7 +38,11 @@ export default function SettingsPage() {
       });
       show("Settings updated");
     } catch (err) {
-      show((err as Error).message);
+      if (err instanceof ApiError) {
+        show(err.message);
+      } else {
+        show((err as Error).message);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- import `ApiError` in pages that perform API requests
- show the API error message when `ApiError` is thrown
- otherwise display a generic failure message via toast notifications

## Testing
- `npm --prefix frontend run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6856ff41da2c832c96de10c33e8dffc8