### PR TITLE
Fix API exports

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,7 +1,56 @@
-export * from './auth';
-export * from './calls';
-export * from './applications';
-export * from './applicationForms';
-export * from './mobilityEntries';
-export * from './reviews';
-export * from './users';
+export {
+  login,
+  register,
+  requestPasswordReset,
+} from './auth';
+
+export {
+  getCalls,
+  getCall,
+  createCall,
+  updateCall,
+  deleteCall,
+} from './calls';
+
+export {
+  createApplication,
+  uploadAttachment,
+  uploadProposal,
+  uploadCV,
+  getApplications,
+  getApplicationsByCall,
+  getApplication,
+  getMyApplications,
+  updateApplication,
+  patchApplication,
+  getApplicationAttachments,
+  deleteAttachment,
+  confirmAttachment,
+} from './applications';
+
+export {
+  createApplicationForm,
+  getApplicationForm,
+  updateApplicationForm,
+} from './applicationForms';
+
+export {
+  getMobilityEntries,
+  createMobilityEntry,
+  updateMobilityEntry,
+  deleteMobilityEntry,
+} from './mobilityEntries';
+
+export {
+  submitReview,
+  getReviewReport,
+  getReviewReports,
+  createReviewReport,
+} from './reviews';
+
+export {
+  createUser,
+  updateUser,
+  getUser,
+  listUsers,
+} from './users';


### PR DESCRIPTION
## Summary
- fix aggregator exports for API methods so that getMobilityEntries and getReviewReports resolve correctly

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68570673f740832cb7769b61fc0f8153