### PR TITLE
Fix mobility entry API functions

### DIFF
--- a/frontend/src/api/mobility_entries.ts
+++ b/frontend/src/api/mobility_entries.ts
@@ -1,5 +1,5 @@
 import { apiFetch } from "../lib/api";
-import type { MobilityEntry } from "../types/mobility_entries";
+import type { MobilityEntry, MobilityEntryInput } from "../types/mobility_entries";
 
 export function getMobilityEntry(id: string) {
   return apiFetch(`/mobility_entries/${id}`) as Promise<MobilityEntry>;
@@ -15,15 +15,22 @@ export function getMobilityEntriesByApplicationForm(applicationFormId: string) {
   ) as Promise<MobilityEntry[]>;
 }
 
-export function createMobilityEntry(data: MobilityEntry) {
+export function getMobilityEntries(applicationFormId: string) {
+  return getMobilityEntriesByApplicationForm(applicationFormId);
+}
+
+export function createMobilityEntry(
+  applicationFormId: string,
+  data: MobilityEntryInput
+) {
   return apiFetch(`/mobility_entries`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(data),
+    body: JSON.stringify({ application_form_id: applicationFormId, ...data }),
   }) as Promise<MobilityEntry>;
 }
 
-export function updateMobilityEntry(id: string, data: MobilityEntry) {
+export function updateMobilityEntry(id: string, data: MobilityEntryInput) {
   return apiFetch(`/mobility_entries/${id}`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- export helper for fetching mobility entries
- include application_form_id when creating mobility entries
- adjust update function to accept partial data

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68570b26d6dc832ca4abf8e678fd64cb