### PR TITLE
Handle duplicate application creation

### DIFF
--- a/frontend/src/pages/calls/Step1_CallInfo.tsx
+++ b/frontend/src/pages/calls/Step1_CallInfo.tsx
@@ -50,13 +50,11 @@ export default function Step1_CallInfo() {
     <div className="space-y-2">
       <h2 className="text-lg font-semibold">{call?.title}</h2>
       <p>{call?.description}</p>
-      <Button onClick={handleCreate} disabled={!!applicationId || loading}>
-        {loading
-          ? "Loading..."
-          : applicationId
-          ? "Application Created"
-          : "Start Application"}
-      </Button>
+      {!applicationId && (
+        <Button onClick={handleCreate} disabled={loading}>
+          {loading ? "Loading..." : "Start Application"}
+        </Button>
+      )}
       {error && <div className="text-red-500">Error: {error}</div>}
     </div>
   );

--- a/frontend/src/pages/calls/Step2_ApplicantInfo.tsx
+++ b/frontend/src/pages/calls/Step2_ApplicantInfo.tsx
@@ -19,7 +19,7 @@ import {
 
 
 export default function Step2_ApplicantInfo() {
-  const { applicationFormId, applicationId, isSubmitted } = useApplication();
+  const { applicationFormId, applicationId, isSubmitted, completeStep } = useApplication();
   const [formData, setFormData] = useState<ApplicationForm | null>(null);
   const { show } = useToast();
   const {
@@ -52,6 +52,7 @@ export default function Step2_ApplicantInfo() {
         ...data,
         application_id: applicationId,
       });
+      await completeStep("step2");
       show("Applicant Info saved");
     } catch (error) {
       show("Failed to save applicant info");

--- a/frontend/src/pages/user/CallPage.tsx
+++ b/frontend/src/pages/user/CallPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { useToast } from "../../context/ToastProvider";
 import { useAuth } from "../../context/AuthProvider";
-import { getCalls } from "../../api";
+import { getCalls, getMyApplications } from "../../api";
 import { ApiError } from "../../lib/api";
 import { UserRole } from "../../types/global";
 import type { Call } from "../../types/global";
@@ -13,6 +13,7 @@ export default function CallPage() {
   const [call, setCall] = useState<Call | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [hasDraft, setHasDraft] = useState(false);
 
   useEffect(() => {
     setLoading(true);
@@ -30,6 +31,16 @@ export default function CallPage() {
       })
       .finally(() => setLoading(false));
   }, [show]);
+
+  useEffect(() => {
+    if (!call || role !== "applicant") return;
+    getMyApplications()
+      .then((apps) => {
+        const found = apps.find((a) => a.call_id === call.id && a.status !== "SUBMITTED");
+        setHasDraft(!!found);
+      })
+      .catch(() => setHasDraft(false));
+  }, [call, role]);
 
   if (loading) return <div className="text-center">Loading...</div>;
   if (error) return <div className="text-red-500 text-center">{error}</div>;
@@ -56,7 +67,7 @@ export default function CallPage() {
               to={`/call/${call.id}/apply`}
               className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
             >
-              Apply Now
+              {hasDraft ? "Continue" : "Apply Now"}
             </Link>
           )}
 


### PR DESCRIPTION
## Summary
- avoid duplicate `Application` creation in the API and return the existing draft
- hide "Start Application" once a draft exists
- mark applicant information as completed on save
- show "Continue" on call page when a draft application already exists

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68570d933714832cace38de3ba660661