### PR TITLE
Fix call info step patch loop

### DIFF
--- a/frontend/src/pages/calls/Step1_CallInfo.tsx
+++ b/frontend/src/pages/calls/Step1_CallInfo.tsx
@@ -6,7 +6,13 @@ import { useApplication } from "../../context/ApplicationProvider";
 
 
 export default function Step1_CallInfo() {
-  const { call, applicationId, createApplication, completeStep } = useApplication();
+  const {
+    call,
+    applicationId,
+    createApplication,
+    completeStep,
+    completedSteps,
+  } = useApplication();
   const { show } = useToast();
   const navigate = useNavigate();
   const [loading, setLoading] = useState<boolean>(false);
@@ -14,10 +20,11 @@ export default function Step1_CallInfo() {
 
   useEffect(() => {
     // If an application already exists, mark this step as completed on load
-    if (applicationId) {
+    if (applicationId && !completedSteps.includes("step1")) {
       completeStep("step1").catch(() => {});
     }
-  }, [applicationId, completeStep]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [applicationId, completedSteps]);
 
   const handleCreate = async () => {
     if (!call?.id) return;


### PR DESCRIPTION
## Summary
- include `completedSteps` from context in `Step1_CallInfo`
- skip completing the step when already marked as done

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6857169ab378832c9bbb1d2ffbd0cc63