### PR TITLE
Fix read_my_applications to exclude deleted records

### DIFF
--- a/backend/app/routes/application.py
+++ b/backend/app/routes/application.py
@@ -70,7 +70,10 @@ def read_my_applications(
     return (
         db.query(Application)
         .options(joinedload(Application.user))
-        .filter(Application.user_id == current_user.id)
+        .filter(
+            Application.user_id == current_user.id,
+            Application.is_deleted.is_(False)
+        )
         .all()
     )
 


### PR DESCRIPTION
## Summary
- avoid listing soft-deleted applications in `read_my_applications`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68571d3dcb30832cb07fcce08c7cc291