### PR TITLE
Fix CV upload error message

### DIFF
--- a/frontend/src/context/ApplicationProvider.tsx
+++ b/frontend/src/context/ApplicationProvider.tsx
@@ -275,6 +275,7 @@ export function ApplicationProvider({
       setAttachments((prev) => [...prev, data]);
       return true;
     } catch {
+      show("Failed to upload file");
       return false;
     }
   };


### PR DESCRIPTION
## Summary
- display a toast notification when CV upload fails

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685721e2ced8832c847e456a8bd176ae