### PR TITLE
Fix mobility type imports

### DIFF
--- a/frontend/src/context/ApplicationProvider.tsx
+++ b/frontend/src/context/ApplicationProvider.tsx
@@ -31,7 +31,7 @@ import {
 import { getCall } from "../api";
 import { Call } from "../types/global";
 import { Attachment } from "../types/attachments";
-import type { MobilityEntry, MobilityEntryInput } from "../types/mobility.types";
+import type { MobilityEntry, MobilityEntryInput } from "../types/mobility_entries";
 import { useToast } from "./ToastProvider";
 import { ApiError } from "../lib/api";
 

--- a/frontend/src/pages/calls/Step6_Mobility.tsx
+++ b/frontend/src/pages/calls/Step6_Mobility.tsx
@@ -4,7 +4,7 @@ import { Button, Input, DatePicker } from "../../components/ui";
 import { useToast } from "../../context/ToastProvider";
 
 import { useApplication } from "../../context/ApplicationProvider";
-import type { MobilityEntryInput, MobilityEntry } from "../../types/mobility.types";
+import type { MobilityEntryInput, MobilityEntry } from "../../types/mobility_entries";
 
 export default function Step6_Mobility() {
   const {

--- a/frontend/src/vite-client.d.ts
+++ b/frontend/src/vite-client.d.ts
@@ -1,0 +1,1 @@
+declare module 'vite/client';


### PR DESCRIPTION
## Summary
- fix mobility entry import paths
- add stub definition for vite/client

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client' and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685721df9254832ca2db05e7e039b61d