### PR TITLE
Fix year_of_birth type handling

### DIFF
--- a/frontend/src/pages/calls/Step2_ApplicantInfo.tsx
+++ b/frontend/src/pages/calls/Step2_ApplicantInfo.tsx
@@ -29,7 +29,7 @@ export default function Step2_ApplicantInfo() {
     formState: { errors, isSubmitting },
   } = useForm<ApplicantInfoForm>({
     resolver: zodResolver(applicantInfoSchema),
-    defaultValues: {},
+    defaultValues: { year_of_birth: undefined },
   });
 
   useEffect(() => {
@@ -50,6 +50,10 @@ export default function Step2_ApplicantInfo() {
       await updateApplicationForm(applicationFormId, {
         ...(formData || {}),
         ...data,
+        year_of_birth:
+          data.year_of_birth !== undefined && data.year_of_birth !== null
+            ? Number(data.year_of_birth)
+            : undefined,
         application_id: applicationId,
       });
       await completeStep("step2");
@@ -76,8 +80,15 @@ export default function Step2_ApplicantInfo() {
           {errors.first_name && <p className="text-red-500 text-sm">{errors.first_name.message}</p>}
         </div>
         <div>
-          <Input {...register("year_of_birth") } placeholder="Year of Birth" disabled={isSubmitted} />
-          {errors.year_of_birth && <p className="text-red-500 text-sm">{errors.year_of_birth.message}</p>}
+          <Input
+            type="number"
+            {...register("year_of_birth")}
+            placeholder="Year of Birth"
+            disabled={isSubmitted}
+          />
+          {errors.year_of_birth && (
+            <p className="text-red-500 text-sm">{errors.year_of_birth.message}</p>
+          )}
         </div>
         <div>
           <Input {...register("nationality") } placeholder="Nationality" disabled={isSubmitted} />

--- a/frontend/src/pages/calls/schemas.ts
+++ b/frontend/src/pages/calls/schemas.ts
@@ -4,11 +4,12 @@ export const applicantInfoSchema = z.object({
   title: z.string().min(1, 'Required'),
   surname: z.string().min(1, 'Required'),
   first_name: z.string().min(1, 'Required'),
-  year_of_birth: z
-    .string()
-    .regex(/^\d{4}$/,'Invalid year')
-    .optional()
-    .or(z.literal('')),
+  year_of_birth: z.coerce
+    .number()
+    .int()
+    .min(1900, 'Invalid year')
+    .max(new Date().getFullYear(), 'Invalid year')
+    .optional(),
   nationality: z.string().min(1, 'Required'),
   organisation: z.string().optional(),
   university: z.string().optional(),


### PR DESCRIPTION
## Summary
- use number defaults in applicant info form
- parse year_of_birth as number before API call
- update applicant info Zod schema to expect a number

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6857247a8548832cb31e1cf8cb72b2d6