### PR TITLE
Fix form field update handling

### DIFF
--- a/frontend/src/pages/calls/Step3_ApplicationDetails.tsx
+++ b/frontend/src/pages/calls/Step3_ApplicationDetails.tsx
@@ -40,16 +40,24 @@ export default function Step3_ApplicationDetails() {
 
   const reg = (name: keyof FormValues) =>
     register(name, {
-      onBlur: (e) => {
+      onBlur: async (e) => {
         if (isSubmitted) return;
         const value =
           e.target.type === "checkbox" ? (e.target as HTMLInputElement).checked : e.target.value;
-        updateApplicationFormField(name, value);
+        try {
+          await updateApplicationFormField(name, value);
+        } catch {
+          show("Failed to update field");
+        }
       },
-      onChange: (e) => {
+      onChange: async (e) => {
         if (isSubmitted) return;
         if (e.target.type === "checkbox") {
-          updateApplicationFormField(name, (e.target as HTMLInputElement).checked);
+          try {
+            await updateApplicationFormField(name, (e.target as HTMLInputElement).checked);
+          } catch {
+            show("Failed to update field");
+          }
         }
       },
     });

--- a/frontend/src/pages/calls/Step8_EthicsSecurity.tsx
+++ b/frontend/src/pages/calls/Step8_EthicsSecurity.tsx
@@ -27,16 +27,20 @@ export default function Step8_EthicsSecurity() {
     setSecuritySelfAssessment(applicationForm.security_self_assessment_text || "");
   }, [applicationForm]);
 
-  const handleChange = () => {
-    updateApplicationFormField("ethics_confirmed", ethicsConfirmed);
-    updateApplicationFormField("ethical_dimension_description", ethicalDescription);
-    updateApplicationFormField("compliance_text", complianceText);
-    updateApplicationFormField(
-      "security_self_assessment_text",
-      securitySelfAssessment
-    );
-    completeStep("step8");
-    show("Section saved");
+  const handleChange = async () => {
+    try {
+      await updateApplicationFormField("ethics_confirmed", ethicsConfirmed);
+      await updateApplicationFormField("ethical_dimension_description", ethicalDescription);
+      await updateApplicationFormField("compliance_text", complianceText);
+      await updateApplicationFormField(
+        "security_self_assessment_text",
+        securitySelfAssessment
+      );
+      await completeStep("step8");
+      show("Section saved");
+    } catch {
+      show("Failed to save section");
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- call `updateApplicationFormField` asynchronously from onBlur/onChange handlers
- use try/catch and show toast notifications if updates fail

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6857247e7ae8832c824a478cfc534991