### PR TITLE
Update step8 save with async handling

### DIFF
--- a/frontend/src/pages/calls/Step8_EthicsSecurity.tsx
+++ b/frontend/src/pages/calls/Step8_EthicsSecurity.tsx
@@ -27,15 +27,23 @@ export default function Step8_EthicsSecurity() {
     setSecuritySelfAssessment(applicationForm.security_self_assessment_text || "");
   }, [applicationForm]);
 
-  const handleChange = () => {
-    updateApplicationFormField("ethics_confirmed", ethicsConfirmed);
-    updateApplicationFormField("ethical_dimension_description", ethicalDescription);
-    updateApplicationFormField("compliance_text", complianceText);
-    updateApplicationFormField(
-      "security_self_assessment_text",
-      securitySelfAssessment
-    );
-    completeStep("step8");
+  const handleChange = async () => {
+    try {
+      await updateApplicationFormField("ethics_confirmed", ethicsConfirmed);
+      await updateApplicationFormField(
+        "ethical_dimension_description",
+        ethicalDescription
+      );
+      await updateApplicationFormField("compliance_text", complianceText);
+      await updateApplicationFormField(
+        "security_self_assessment_text",
+        securitySelfAssessment
+      );
+    } catch {
+      show("Failed to save section");
+      return;
+    }
+    await completeStep("step8");
     show("Section saved");
   };
 


### PR DESCRIPTION
## Summary
- make the `handleChange` function asynchronous
- await each call to `updateApplicationFormField`
- show an error toast and skip completing the step if an update fails

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68572486f17c832ca08cfd6c21d40ddc