### PR TITLE
Update context default

### DIFF
--- a/frontend/src/context/ApplicationProvider.tsx
+++ b/frontend/src/context/ApplicationProvider.tsx
@@ -85,6 +85,8 @@ const ApplicationContext = createContext<ApplicationContextValue>({
   updateApplicationField: async () => {},
   updateApplicationFormField: async () => {},
   completeStep: async () => {},
+  markPartialStep: () => {},
+  clearPartialStep: () => {},
   isSubmitted: false,
 });
 


### PR DESCRIPTION
## Summary
- add missing partial step handlers to the default `ApplicationContext` value

## Testing
- `npm --prefix frontend run build` *(fails: Cannot find type definition file for 'vite/client')*
- `npm --prefix frontend install` *(fails due to missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_68572678704c832c93c67b2c0bdedea0