### PR TITLE
Add application_form_id field to Application type

### DIFF
--- a/frontend/src/types/applications.ts
+++ b/frontend/src/types/applications.ts
@@ -13,6 +13,7 @@ export interface Application extends ApplicationInput {
   id: string;
   created_at?: string | null;
   updated_at?: string | null;
+  application_form_id?: string | null;
 }
 
 export interface ApplicationOut extends Application {


### PR DESCRIPTION
## Summary
- extend `Application` interface with `application_form_id` field

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68572678de74832c916670f995e31ebe